### PR TITLE
chore(plugins): bump DynamoDB plugin to v0.1.5

### DIFF
--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -382,17 +382,17 @@
       "description": "Tabularis driver plugin for AWS DynamoDB",
       "author": "fuleinist <https://github.com/fuleinist>",
       "homepage": "https://github.com/TabularisDB/tabularis-dynamodb-plugin",
-      "latest_version": "0.1.4",
+      "latest_version": "0.1.5",
       "releases": [
         {
-          "version": "0.1.4",
+          "version": "0.1.5",
           "min_tabularis_version": "0.15.0",
           "assets": {
-            "linux-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.4/dynamodb-plugin-linux-x64.zip",
-            "linux-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.4/dynamodb-plugin-linux-arm64.zip",
-            "darwin-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.4/dynamodb-plugin-darwin-x64.zip",
-            "darwin-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.4/dynamodb-plugin-darwin-arm64.zip",
-            "win-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.4/dynamodb-plugin-win-x64.zip"
+            "linux-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.5/dynamodb-plugin-linux-x64.zip",
+            "linux-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.5/dynamodb-plugin-linux-arm64.zip",
+            "darwin-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.5/dynamodb-plugin-darwin-x64.zip",
+            "darwin-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.5/dynamodb-plugin-darwin-arm64.zip",
+            "win-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.5/dynamodb-plugin-win-x64.zip"
           }
         }
       ]

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -382,48 +382,17 @@
       "description": "Tabularis driver plugin for AWS DynamoDB",
       "author": "fuleinist <https://github.com/fuleinist>",
       "homepage": "https://github.com/TabularisDB/tabularis-dynamodb-plugin",
-      "latest_version": "0.1.3",
+      "latest_version": "0.1.4",
       "releases": [
         {
-          "version": "0.1.3",
+          "version": "0.1.4",
           "min_tabularis_version": "0.15.0",
           "assets": {
-            "linux-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.3/dynamodb-plugin-linux-x64.zip",
-            "linux-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.3/dynamodb-plugin-linux-arm64.zip",
-            "darwin-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.3/dynamodb-plugin-darwin-x64.zip",
-            "darwin-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.3/dynamodb-plugin-darwin-arm64.zip",
-            "win-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.3/dynamodb-plugin-win-x64.zip"
-          }
-        },
-        {
-          "version": "0.1.2",
-          "min_tabularis_version": "0.15.0",
-          "assets": {
-            "linux-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.2/dynamodb-plugin-linux-x64.zip",
-            "linux-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.2/dynamodb-plugin-linux-arm64.zip",
-            "darwin-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.2/dynamodb-plugin-darwin-x64.zip",
-            "darwin-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.2/dynamodb-plugin-darwin-arm64.zip",
-            "win-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.2/dynamodb-plugin-win-x64.zip"
-          }
-        },
-        {
-          "version": "0.1.1",
-          "min_tabularis_version": "0.15.0",
-          "assets": {
-            "linux-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.1/dynamodb-plugin-linux-x64.zip",
-            "linux-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.1/dynamodb-plugin-linux-arm64.zip",
-            "darwin-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.1/dynamodb-plugin-darwin-x64.zip",
-            "darwin-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.1/dynamodb-plugin-darwin-arm64.zip",
-            "win-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.1/dynamodb-plugin-win-x64.zip"
-          }
-        },
-        {
-          "version": "0.1.0",
-          "min_tabularis_version": "0.15.0",
-          "assets": {
-            "linux-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.0/dynamodb-plugin-linux-x64.zip",
-            "darwin-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.0/dynamodb-plugin-darwin-arm64.zip",
-            "win-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.0/dynamodb-plugin-win-x64.zip"
+            "linux-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.4/dynamodb-plugin-linux-x64.zip",
+            "linux-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.4/dynamodb-plugin-linux-arm64.zip",
+            "darwin-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.4/dynamodb-plugin-darwin-x64.zip",
+            "darwin-arm64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.4/dynamodb-plugin-darwin-arm64.zip",
+            "win-x64": "https://github.com/TabularisDB/tabularis-dynamodb-plugin/releases/download/v0.1.4/dynamodb-plugin-win-x64.zip"
           }
         }
       ]


### PR DESCRIPTION
Bump DynamoDB plugin to v0.1.5 in the plugin registry.

## v0.1.5 (2026-08-07)

### Added
- **Plugin icon** — Official Amazon DynamoDB brand icon (SVG) added to the `.tabularium` manifest, following the same pattern as other plugins (e.g., DuckDB).

Companion PR: https://github.com/TabularisDB/tabularis-dynamodb-plugin/pull/61