### PR TITLE
feat(editor): add SQL query folding previews

### DIFF
--- a/src/components/ui/SqlEditorWrapper.tsx
+++ b/src/components/ui/SqlEditorWrapper.tsx
@@ -17,6 +17,11 @@ import {
 import { formatSql } from "../../utils/sqlFormat";
 import type { SqlDialect } from "../../utils/sql";
 import type { RunContext } from "../../utils/runTarget";
+import {
+  registerSqlFoldingProvider,
+  setSqlFoldingDialect,
+} from "../../utils/sqlFolding";
+import { installSqlFoldPreview } from "../../utils/sqlFoldPreview";
 
 interface SqlEditorWrapperProps {
   initialValue: string;
@@ -36,6 +41,8 @@ interface SqlEditorWrapperProps {
    * the button with its actual target. Requires `dialect`.
    */
   onRunContextChange?: (context: RunContext) => void;
+  /** Shows the complete query when hovering a collapsed fold. */
+  foldPreview?: boolean;
 }
 
 function isLinux(): boolean {
@@ -56,11 +63,13 @@ const SqlEditorInternal = ({
   options,
   dialect,
   onRunAll,
-  onRunContextChange
+  onRunContextChange,
+  foldPreview = false,
 }: SqlEditorWrapperProps & { editorKey: string }) => {
   const updateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
   const monacoRef = useRef<typeof Monaco | null>(null);
+  const foldPreviewRef = useRef<Monaco.IDisposable | null>(null);
   const onRunRef = useRef(onRun);
   onRunRef.current = onRun;
   const onRunAllRef = useRef(onRunAll);
@@ -95,6 +104,8 @@ const SqlEditorInternal = ({
       if (updateTimeoutRef.current) {
         clearTimeout(updateTimeoutRef.current);
       }
+      foldPreviewRef.current?.dispose();
+      foldPreviewRef.current = null;
       editorRef.current?.dispose();
       editorRef.current = null;
       monacoRef.current = null;
@@ -113,6 +124,10 @@ const SqlEditorInternal = ({
       if (selections && selections.length > 0) editor.setSelections(selections);
     }
   }, [initialValue]);
+
+  useEffect(() => {
+    setSqlFoldingDialect(editorRef.current?.getModel() ?? null, dialect);
+  }, [dialect]);
 
   // Update Monaco theme when theme changes
   useEffect(() => {
@@ -168,8 +183,9 @@ const SqlEditorInternal = ({
     );
 
     const handleBeforeMount: BeforeMount = (monaco) => {
-      // Load Monaco theme before editor is created
+      // Load Monaco theme and SQL language features before the editor is created.
       loadMonacoTheme(editorTheme, monaco);
+      registerSqlFoldingProvider(monaco);
     };
 
     const tauriPaste = async (ed: Monaco.editor.ICodeEditor) => {
@@ -242,6 +258,14 @@ const SqlEditorInternal = ({
     const handleEditorMount: OnMount = (editor, monaco) => {
       editorRef.current = editor;
       monacoRef.current = monaco;
+      setSqlFoldingDialect(editor.getModel(), dialectRef.current);
+      if (foldPreview) {
+        foldPreviewRef.current = installSqlFoldPreview(
+          editor,
+          monaco,
+          () => dialectRef.current,
+        );
+      }
 
       if (typeof document !== "undefined" && document.fonts) {
         document.fonts.ready.then(() => monaco.editor.remeasureFonts());
@@ -506,6 +530,8 @@ const SqlEditorInternal = ({
           tabSize: settings.editorTabSize ?? 2,
           wordWrap: (settings.editorWordWrap ?? true) ? 'on' : 'off',
           lineNumbers: (settings.editorShowLineNumbers ?? true) ? 'on' : 'off',
+          folding: true,
+          showFoldingControls: 'always',
           padding: { top: 16, bottom: 32 },
           scrollBeyondLastLine: false,
           overviewRulerLanes: 0,

--- a/src/index.css
+++ b/src/index.css
@@ -471,6 +471,39 @@ select option:active {
   background-color: color-mix(in srgb, var(--accent-primary) 10%, transparent);
 }
 
+/* Read-only preview shown when hovering a collapsed SQL query. */
+.sql-fold-preview {
+  position: fixed;
+  z-index: 10000;
+  min-width: 240px;
+  max-width: min(620px, calc(100vw - 24px));
+  overflow: hidden;
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  background: var(--bg-base);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 28%);
+  pointer-events: auto;
+}
+
+.sql-fold-preview-code {
+  max-height: min(480px, calc(100vh - 48px));
+  margin: 0;
+  padding: 8px 10px;
+  overflow: auto;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.sql-fold-preview-footer {
+  padding: 5px 10px;
+  border-top: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
 /* Sidebar slide-in animation */
 @keyframes slide-in-right {
   from {

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -3980,6 +3980,7 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
                 height="100%"
                 initialValue={tab.query}
                 dialect={activeDialect}
+                foldPreview
                 onChange={(val) => {
                   if (isActive) updateTab(tab.id, { query: val });
                 }}

--- a/src/utils/sqlFoldPreview.ts
+++ b/src/utils/sqlFoldPreview.ts
@@ -1,0 +1,129 @@
+import type * as Monaco from "monaco-editor";
+import type { Dialect } from "./sqlSplitter";
+import { getSqlQueryAtFoldLine } from "./sqlFolding";
+
+const HOVER_DELAY_MS = 400;
+const DISMISS_DELAY_MS = 150;
+const PREVIEW_CHARACTER_LIMIT = 20_000;
+
+function isFoldPlaceholder(element: HTMLElement | null): boolean {
+  return Boolean(element?.closest(".inline-folded"));
+}
+
+function positionPreview(preview: HTMLElement, x: number, y: number): void {
+  const margin = 12;
+  const rect = preview.getBoundingClientRect();
+  const left = Math.max(
+    margin,
+    Math.min(x, window.innerWidth - rect.width - margin),
+  );
+  const below = y + margin;
+  const top = below + rect.height <= window.innerHeight - margin
+    ? below
+    : Math.max(margin, y - rect.height - margin);
+  preview.style.left = `${left}px`;
+  preview.style.top = `${top}px`;
+}
+
+/** Installs a TablePro-style preview over Monaco's collapsed-fold placeholder. */
+export function installSqlFoldPreview(
+  editor: Monaco.editor.ICodeEditor,
+  monaco: typeof Monaco,
+  dialect: () => Dialect | string | undefined,
+): Monaco.IDisposable {
+  let preview: HTMLDivElement | null = null;
+  let hoverTimer: ReturnType<typeof setTimeout> | null = null;
+  let dismissTimer: ReturnType<typeof setTimeout> | null = null;
+  let activeLine: number | null = null;
+  let requestId = 0;
+
+  const cancelScheduledDismiss = (): void => {
+    if (dismissTimer) clearTimeout(dismissTimer);
+    dismissTimer = null;
+  };
+
+  const dismiss = (): void => {
+    requestId += 1;
+    activeLine = null;
+    if (hoverTimer) clearTimeout(hoverTimer);
+    hoverTimer = null;
+    cancelScheduledDismiss();
+    preview?.remove();
+    preview = null;
+  };
+
+  const scheduleDismiss = (): void => {
+    cancelScheduledDismiss();
+    dismissTimer = setTimeout(dismiss, DISMISS_DELAY_MS);
+  };
+
+  const show = async (query: string, x: number, y: number): Promise<void> => {
+    const currentRequest = ++requestId;
+    const truncated = query.length > PREVIEW_CHARACTER_LIMIT;
+    const text = truncated ? query.slice(0, PREVIEW_CHARACTER_LIMIT) : query;
+    const html = await monaco.editor.colorize(text, "sql", { tabSize: 2 });
+    if (currentRequest !== requestId) return;
+
+    const container = document.createElement("div");
+    container.className = "sql-fold-preview";
+    container.setAttribute("role", "tooltip");
+    container.addEventListener("mouseenter", cancelScheduledDismiss);
+    container.addEventListener("mouseleave", dismiss);
+
+    const code = document.createElement("pre");
+    code.className = "sql-fold-preview-code";
+    code.innerHTML = html;
+    container.appendChild(code);
+
+    if (truncated) {
+      const footer = document.createElement("div");
+      footer.className = "sql-fold-preview-footer";
+      footer.textContent = "Preview truncated";
+      container.appendChild(footer);
+    }
+
+    document.body.appendChild(container);
+    positionPreview(container, x, y);
+    preview = container;
+  };
+
+  const mouseMove = editor.onMouseMove((event) => {
+    const line = event.target.position?.lineNumber ?? null;
+    if (!line || !isFoldPlaceholder(event.target.element)) {
+      scheduleDismiss();
+      return;
+    }
+    cancelScheduledDismiss();
+    if (activeLine === line) return;
+
+    dismiss();
+    const model = editor.getModel();
+    const query = model
+      ? getSqlQueryAtFoldLine(model.getValue(), line, dialect())
+      : null;
+    if (!query) return;
+
+    activeLine = line;
+    const { posx, posy } = event.event;
+    hoverTimer = setTimeout(() => {
+      hoverTimer = null;
+      void show(query, posx, posy);
+    }, HOVER_DELAY_MS);
+  });
+
+  const disposables = [
+    mouseMove,
+    editor.onMouseLeave(scheduleDismiss),
+    editor.onDidChangeModelContent(dismiss),
+    editor.onDidScrollChange(dismiss),
+  ];
+  window.addEventListener("blur", dismiss);
+
+  return {
+    dispose() {
+      dismiss();
+      disposables.forEach((disposable) => disposable.dispose());
+      window.removeEventListener("blur", dismiss);
+    },
+  };
+}

--- a/src/utils/sqlFolding.ts
+++ b/src/utils/sqlFolding.ts
@@ -1,0 +1,103 @@
+import type * as Monaco from "monaco-editor";
+import {
+  splitStatements,
+  type Dialect,
+} from "./sqlSplitter";
+
+export interface SqlFoldingRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+const MAX_FOLDABLE_CHARACTERS = 2_000_000;
+const registeredMonacoInstances = new WeakSet<object>();
+const modelDialects = new WeakMap<
+  Monaco.editor.ITextModel,
+  Dialect | string | undefined
+>();
+const foldingChangeListeners = new Set<() => void>();
+
+function lineStarts(source: string): number[] {
+  const starts = [0];
+  for (let index = 0; index < source.length; index += 1) {
+    if (source[index] === "\n") starts.push(index + 1);
+  }
+  return starts;
+}
+
+function lineAtOffset(starts: ReadonlyArray<number>, offset: number): number {
+  let low = 0;
+  let high = starts.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (starts[middle] <= offset) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+/** Returns one fold for each SQL statement that spans multiple lines. */
+export function getSqlFoldingRanges(
+  source: string,
+  dialect?: Dialect | string,
+): SqlFoldingRange[] {
+  const starts = lineStarts(source);
+  return splitStatements(source, dialect).flatMap((statement) => {
+    const start = lineAtOffset(starts, statement.range.start);
+    const end = lineAtOffset(starts, Math.max(statement.range.start, statement.range.end - 1));
+    return end > start ? [{ start, end }] : [];
+  });
+}
+
+/** Returns the complete query whose fold starts on the given line. */
+export function getSqlQueryAtFoldLine(
+  source: string,
+  line: number,
+  dialect?: Dialect | string,
+): string | null {
+  const starts = lineStarts(source);
+  const statement = splitStatements(source, dialect).find((candidate) => {
+    const start = lineAtOffset(starts, candidate.range.start);
+    const end = lineAtOffset(
+      starts,
+      Math.max(candidate.range.start, candidate.range.end - 1),
+    );
+    return start === line && end > start;
+  });
+  return statement
+    ? source.slice(statement.range.start, statement.range.end)
+    : null;
+}
+
+export function setSqlFoldingDialect(
+  model: Monaco.editor.ITextModel | null,
+  dialect?: Dialect | string,
+): void {
+  if (!model || modelDialects.get(model) === dialect) return;
+  modelDialects.set(model, dialect);
+  foldingChangeListeners.forEach((notify) => notify());
+}
+
+/** Registers the query folding provider once for each Monaco instance. */
+export function registerSqlFoldingProvider(monaco: typeof Monaco): void {
+  if (registeredMonacoInstances.has(monaco)) return;
+  registeredMonacoInstances.add(monaco);
+
+  const provider: Monaco.languages.FoldingRangeProvider = {
+    onDidChange(listener) {
+      const notify = (): void => listener(provider);
+      foldingChangeListeners.add(notify);
+      return { dispose: () => foldingChangeListeners.delete(notify) };
+    },
+    provideFoldingRanges(model) {
+      if (model.getValueLength() > MAX_FOLDABLE_CHARACTERS) return [];
+      return getSqlFoldingRanges(model.getValue(), modelDialects.get(model)).map(
+        (range) => ({
+          ...range,
+          kind: monaco.languages.FoldingRangeKind.Region,
+        }),
+      );
+    },
+  };
+  monaco.languages.registerFoldingRangeProvider("sql", provider);
+}

--- a/tests/components/ui/SqlEditorWrapper.test.tsx
+++ b/tests/components/ui/SqlEditorWrapper.test.tsx
@@ -7,9 +7,14 @@ import type { ReactNode } from 'react';
 
 interface MonacoEditorMockProps {
   onChange?: (value: string) => void;
+  beforeMount?: (monaco: unknown) => void;
   onMount?: (editor: unknown, monaco: unknown) => void;
   defaultValue?: string;
-  options?: { acceptSuggestionOnEnter?: string };
+  options?: {
+    acceptSuggestionOnEnter?: string;
+    folding?: boolean;
+    showFoldingControls?: string;
+  };
 }
 
 interface MonacoKeyDownEventMock {
@@ -19,8 +24,14 @@ interface MonacoKeyDownEventMock {
 }
 
 const monacoRenderState = vi.hoisted(() => ({
+  beforeMount: undefined as MonacoEditorMockProps['beforeMount'],
   onMount: undefined as MonacoEditorMockProps['onMount'],
 }));
+const registerSqlFoldingProviderMock = vi.hoisted(() => vi.fn());
+const setSqlFoldingDialectMock = vi.hoisted(() => vi.fn());
+const installSqlFoldPreviewMock = vi.hoisted(() =>
+  vi.fn(() => ({ dispose: vi.fn() })),
+);
 const matchesShortcutMock = vi.hoisted(() =>
   vi.fn<(event: KeyboardEvent, id: string) => boolean>(),
 );
@@ -30,12 +41,15 @@ const closePaletteMock = vi.hoisted(() => vi.fn());
 // Mock MonacoEditor
 vi.mock('@monaco-editor/react', async () => {
   return {
-    default: ({ onChange, onMount, defaultValue, options }: MonacoEditorMockProps) => {
+    default: ({ onChange, beforeMount, onMount, defaultValue, options }: MonacoEditorMockProps) => {
+      monacoRenderState.beforeMount = beforeMount;
       monacoRenderState.onMount = onMount;
       return (
         <textarea
           data-testid="monaco-editor"
           data-accept-suggestion-on-enter={options?.acceptSuggestionOnEnter}
+          data-folding={String(options?.folding)}
+          data-folding-controls={options?.showFoldingControls}
           defaultValue={defaultValue}
           onChange={(e) => onChange?.(e.target.value)}
         />
@@ -61,6 +75,15 @@ vi.mock('../../../src/hooks/useKeybindings', () => ({
 // Mock themeUtils
 vi.mock('../../../src/themes/themeUtils', () => ({
   loadMonacoTheme: vi.fn(),
+}));
+
+vi.mock('../../../src/utils/sqlFolding', () => ({
+  registerSqlFoldingProvider: registerSqlFoldingProviderMock,
+  setSqlFoldingDialect: setSqlFoldingDialectMock,
+}));
+
+vi.mock('../../../src/utils/sqlFoldPreview', () => ({
+  installSqlFoldPreview: installSqlFoldPreviewMock,
 }));
 
 // Mock monaco KeyMod and KeyCode
@@ -102,6 +125,7 @@ describe('SqlEditorWrapper', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    monacoRenderState.beforeMount = undefined;
     monacoRenderState.onMount = undefined;
     matchesShortcutMock.mockReturnValue(false);
   });
@@ -115,6 +139,7 @@ describe('SqlEditorWrapper', () => {
       addCommand,
       dispose: vi.fn(),
       getContribution: vi.fn(() => null),
+      getModel: vi.fn(() => null),
       onKeyDown: vi.fn((handler: (event: MonacoKeyDownEventMock) => void) => {
         keyDownHandlers.push(handler);
       }),
@@ -142,6 +167,43 @@ describe('SqlEditorWrapper', () => {
     );
 
     expect(screen.getByTestId('monaco-editor')).toHaveValue('SELECT * FROM users');
+  });
+
+  it('enables and registers SQL code folding', () => {
+    render(
+      <SqlEditorWrapper
+        initialValue="SELECT 1"
+        onChange={mockOnChange}
+        onRun={mockOnRun}
+        dialect="postgres"
+      />,
+      { wrapper },
+    );
+
+    expect(screen.getByTestId('monaco-editor')).toHaveAttribute('data-folding', 'true');
+    expect(screen.getByTestId('monaco-editor')).toHaveAttribute(
+      'data-folding-controls',
+      'always',
+    );
+
+    const monaco = {};
+    monacoRenderState.beforeMount?.(monaco);
+    expect(registerSqlFoldingProviderMock).toHaveBeenCalledWith(monaco);
+  });
+
+  it('installs fold previews only when requested', () => {
+    render(
+      <SqlEditorWrapper
+        initialValue="SELECT 1"
+        onChange={mockOnChange}
+        onRun={mockOnRun}
+        foldPreview
+      />,
+      { wrapper },
+    );
+
+    mountCapturedEditor();
+    expect(installSqlFoldPreviewMock).toHaveBeenCalledOnce();
   });
 
   it('renders editor component', async () => {

--- a/tests/utils/sqlFoldPreview.test.ts
+++ b/tests/utils/sqlFoldPreview.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type * as Monaco from "monaco-editor";
+import { installSqlFoldPreview } from "../../src/utils/sqlFoldPreview";
+
+describe("sqlFoldPreview", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    document.querySelectorAll(".sql-fold-preview").forEach((node) => node.remove());
+  });
+
+  it("shows the complete folded query after hovering Monaco's placeholder", async () => {
+    vi.useFakeTimers();
+    let mouseMove: ((event: Monaco.editor.IEditorMouseEvent) => void) | undefined;
+    let mouseLeave: (() => void) | undefined;
+    const disposable = (): Monaco.IDisposable => ({ dispose: vi.fn() });
+    const editor = {
+      getModel: () => ({ getValue: () => "SELECT\n  1;" }),
+      onMouseMove: (listener: (event: Monaco.editor.IEditorMouseEvent) => void) => {
+        mouseMove = listener;
+        return disposable();
+      },
+      onMouseLeave: (listener: () => void) => {
+        mouseLeave = listener;
+        return disposable();
+      },
+      onDidChangeModelContent: () => disposable(),
+      onDidScrollChange: () => disposable(),
+    } as unknown as Monaco.editor.ICodeEditor;
+    const colorize = vi.fn(async (text: string) => `<span>${text}</span>`);
+    const monaco = { editor: { colorize } } as unknown as typeof Monaco;
+    const placeholder = document.createElement("span");
+    placeholder.className = "inline-folded";
+
+    const installation = installSqlFoldPreview(editor, monaco, () => "postgres");
+    mouseMove?.({
+      event: { posx: 100, posy: 80 },
+      target: { element: placeholder, position: { lineNumber: 1, column: 1 } },
+    } as unknown as Monaco.editor.IEditorMouseEvent);
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(colorize).toHaveBeenCalledWith("SELECT\n  1", "sql", { tabSize: 2 });
+    expect(document.querySelector(".sql-fold-preview-code")).toHaveTextContent(
+      "SELECT 1",
+    );
+
+    mouseLeave?.();
+    const preview = document.querySelector<HTMLElement>(".sql-fold-preview");
+    preview?.dispatchEvent(new MouseEvent("mouseenter"));
+    await vi.advanceTimersByTimeAsync(150);
+    expect(document.querySelector(".sql-fold-preview")).toBe(preview);
+
+    preview?.dispatchEvent(new MouseEvent("mouseleave"));
+    expect(document.querySelector(".sql-fold-preview")).toBeNull();
+    installation.dispose();
+  });
+
+  it("does not preview regular editor text", async () => {
+    vi.useFakeTimers();
+    let mouseMove: ((event: Monaco.editor.IEditorMouseEvent) => void) | undefined;
+    const disposable = (): Monaco.IDisposable => ({ dispose: vi.fn() });
+    const editor = {
+      getModel: () => ({ getValue: () => "SELECT\n  1;" }),
+      onMouseMove: (listener: (event: Monaco.editor.IEditorMouseEvent) => void) => {
+        mouseMove = listener;
+        return disposable();
+      },
+      onMouseLeave: () => disposable(),
+      onDidChangeModelContent: () => disposable(),
+      onDidScrollChange: () => disposable(),
+    } as unknown as Monaco.editor.ICodeEditor;
+    const colorize = vi.fn(async () => "");
+    const monaco = { editor: { colorize } } as unknown as typeof Monaco;
+    const text = document.createElement("span");
+
+    const installation = installSqlFoldPreview(editor, monaco, () => "postgres");
+    mouseMove?.({
+      event: { posx: 100, posy: 80 },
+      target: { element: text, position: { lineNumber: 1, column: 1 } },
+    } as unknown as Monaco.editor.IEditorMouseEvent);
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(colorize).not.toHaveBeenCalled();
+    expect(document.querySelector(".sql-fold-preview")).toBeNull();
+    installation.dispose();
+  });
+});

--- a/tests/utils/sqlFolding.test.ts
+++ b/tests/utils/sqlFolding.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import type * as Monaco from "monaco-editor";
+import {
+  getSqlFoldingRanges,
+  getSqlQueryAtFoldLine,
+  registerSqlFoldingProvider,
+  setSqlFoldingDialect,
+} from "../../src/utils/sqlFolding";
+
+describe("sqlFolding", () => {
+  it("does not fold a single-line query", () => {
+    expect(getSqlFoldingRanges("SELECT 1;")).toEqual([]);
+  });
+
+  it("creates one fold for each multiline query", () => {
+    expect(
+      getSqlFoldingRanges("SELECT\n  1;\n\nSELECT\n  2;"),
+    ).toEqual([
+      { start: 1, end: 2 },
+      { start: 4, end: 5 },
+    ]);
+  });
+
+  it("returns the complete query behind a fold", () => {
+    const sql = "SELECT\n  1;\n\nSELECT\n  2;";
+    expect(getSqlQueryAtFoldLine(sql, 1)).toBe("SELECT\n  1");
+    expect(getSqlQueryAtFoldLine(sql, 4)).toBe("SELECT\n  2");
+    expect(getSqlQueryAtFoldLine(sql, 2)).toBeNull();
+  });
+
+  it("does not create separate folds for nested SQL structures", () => {
+    expect(
+      getSqlFoldingRanges(
+        "SELECT *\nFROM (\n  SELECT id\n  FROM users\n) nested;",
+      ),
+    ).toEqual([{ start: 1, end: 5 }]);
+  });
+
+  it("uses the selected dialect when splitting queries", () => {
+    const mysql = "SELECT\n  'a;\\'b';\nSELECT\n  2;";
+    expect(getSqlFoldingRanges(mysql, "mysql")).toEqual([
+      { start: 1, end: 2 },
+      { start: 3, end: 4 },
+    ]);
+  });
+
+  it("registers one dialect-aware Monaco provider per instance", () => {
+    let provider: Monaco.languages.FoldingRangeProvider | undefined;
+    const registerFoldingRangeProvider = vi.fn(
+      (_language: string, nextProvider: Monaco.languages.FoldingRangeProvider) => {
+        provider = nextProvider;
+        return { dispose: vi.fn() };
+      },
+    );
+    const monaco = {
+      languages: {
+        registerFoldingRangeProvider,
+        FoldingRangeKind: { Region: { value: "region" } },
+      },
+    } as unknown as typeof Monaco;
+    const model = {
+      getValue: () => "SELECT\n  1;",
+      getValueLength: () => 11,
+    } as unknown as Monaco.editor.ITextModel;
+
+    registerSqlFoldingProvider(monaco);
+    registerSqlFoldingProvider(monaco);
+    setSqlFoldingDialect(model, "postgres");
+
+    expect(registerFoldingRangeProvider).toHaveBeenCalledTimes(1);
+    expect(provider).toBeDefined();
+    expect(
+      provider?.provideFoldingRanges(
+        model,
+        {},
+        { isCancellationRequested: false, onCancellationRequested: vi.fn() },
+      ),
+    ).toEqual([{ start: 1, end: 2, kind: { value: "region" } }]);
+  });
+});


### PR DESCRIPTION
## Summary

- add dialect-aware folding ranges for individual multiline SQL statements
- keep fold controls visible in the Monaco gutter
- show a syntax-highlighted query preview when hovering a collapsed fold
- allow moving into and scrolling the preview without expanding the query
- scope interactive previews to the main query editor

## Validation

- `pnpm test --run` — 232 files, 3,844 tests passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
- GitNexus change detection — low risk, no affected processes
