### PR TITLE
fix: show production banner only in editor

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -32,7 +32,7 @@ const MainLayoutContent = () => {
       <CommandPaletteScopeBridge scopeId={ROOT_COMMAND_SCOPE_ID} />
       <Sidebar />
       <main className="flex-1 flex flex-col min-w-0 overflow-hidden">
-        <ProductionBanner />
+        {location.pathname === "/editor" && <ProductionBanner />}
         {renderedSplit ? (
           <SplitPaneLayout {...renderedSplit} />
         ) : (

--- a/tests/components/layout/MainLayout.test.tsx
+++ b/tests/components/layout/MainLayout.test.tsx
@@ -18,7 +18,7 @@ vi.mock("../../../src/components/layout/SplitPaneLayout", () => ({
 }));
 
 vi.mock("../../../src/components/layout/ProductionBanner", () => ({
-  ProductionBanner: () => null,
+  ProductionBanner: () => <div data-testid="production-banner" />,
 }));
 
 vi.mock("../../../src/components/layout/CommandPaletteScopeBridge", () => ({
@@ -67,5 +67,35 @@ describe("MainLayout", () => {
     );
 
     expect(screen.getByTestId("palette-host")).toBeInTheDocument();
+  });
+
+  it("should show the production banner only on the connection editor route", () => {
+    const { unmount } = render(
+      <MemoryRouter initialEntries={["/editor"]}>
+        <Routes>
+          <Route element={<MainLayout />}>
+            <Route path="editor" element={<div>Editor</div>} />
+            <Route path="settings" element={<div>Settings</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("production-banner")).toBeInTheDocument();
+
+    unmount();
+
+    render(
+      <MemoryRouter initialEntries={["/settings"]}>
+        <Routes>
+          <Route element={<MainLayout />}>
+            <Route path="editor" element={<div>Editor</div>} />
+            <Route path="settings" element={<div>Settings</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId("production-banner")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- render the production environment banner only on the connection editor route
- prevent the banner from persisting on Settings and other non-connection views
- add regression coverage for editor and Settings routes

## Testing
- `pnpm test tests/components/layout/MainLayout.test.tsx --run`
- `pnpm typecheck`
- `pnpm exec eslint src/components/layout/MainLayout.tsx`