### PR TITLE
feat(grid): spreadsheet-style keyboard selection and header column select

### DIFF
--- a/src/components/ui/DataGrid.tsx
+++ b/src/components/ui/DataGrid.tsx
@@ -59,6 +59,10 @@ import {
   type PasteTarget,
   type ColumnDisplayInfo,
   type MergedRow,
+  buildCellRange,
+  extendCellRange,
+  moveCellPosition,
+  type RangeExtendKey,
 } from "../../utils/dataGrid";
 import { readText } from "@tauri-apps/plugin-clipboard-manager";
 import { useSettings } from "../../hooks/useSettings";
@@ -165,6 +169,15 @@ const NAVIGATION_KEYS = new Set([
   "PageDown",
   "Enter",
   "F2",
+]);
+
+// Arrow keys that, with Shift held, extend the cell range instead of moving
+// the focused cell.
+const RANGE_EXTEND_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
 ]);
 
 export const DataGrid = React.memo(
@@ -600,8 +613,9 @@ export const DataGrid = React.memo(
       [selectedRowIndices, lastSelectedRowIndex, updateSelection],
     );
 
-    // Column header selection: Cmd/Ctrl+click toggles one column, Shift+click
-    // range-selects from the anchor. Plain click stays reserved for sorting.
+    // Column header selection (spreadsheet-style): plain click selects the
+    // column, Cmd/Ctrl+click toggles it, Shift+click range-selects from the
+    // anchor. Sorting lives on the header's sort button.
     const handleColumnHeaderSelect = useCallback(
       (index: number, event: React.MouseEvent) => {
         setFocusedCell(null);
@@ -613,8 +627,11 @@ export const DataGrid = React.memo(
           setSelectedColIndices(
             new Set(calculateSelectionRange(lastSelectedColIndex, index)),
           );
-        } else {
+        } else if (event.ctrlKey || event.metaKey) {
           setSelectedColIndices((prev) => toggleSetValue(prev, index));
+          setLastSelectedColIndex(index);
+        } else {
+          setSelectedColIndices(new Set([index]));
           setLastSelectedColIndex(index);
         }
       },
@@ -632,12 +649,7 @@ export const DataGrid = React.memo(
     const handleCellClick = useCallback(
       (rowIndex: number, colIndex: number, event: React.MouseEvent) => {
         if (event.shiftKey && focusedCell) {
-          setCellRange({
-            minRow: Math.min(focusedCell.rowIndex, rowIndex),
-            maxRow: Math.max(focusedCell.rowIndex, rowIndex),
-            minCol: Math.min(focusedCell.colIndex, colIndex),
-            maxCol: Math.max(focusedCell.colIndex, colIndex),
-          });
+          setCellRange(buildCellRange(focusedCell, { rowIndex, colIndex }));
         } else {
           setFocusedCell({ rowIndex, colIndex });
           setCellRange(null);
@@ -1239,45 +1251,57 @@ export const DataGrid = React.memo(
 
               return (
                 <div
-                  role={onSort ? "button" : undefined}
-                  tabIndex={onSort ? 0 : undefined}
-                  aria-label={onSort ? (
-                    displaySortState === "none"
-                      ? t("dataGrid.sortByAsc", { col: colName })
-                      : displaySortState === "asc"
-                        ? t("dataGrid.sortByDesc", { col: colName })
-                        : t("dataGrid.clearSort")
-                  ) : undefined}
-                  className={`relative flex items-center gap-2 select-none group/header ${onSort ? "cursor-pointer" : ""}`}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={t("dataGrid.selectColumn")}
+                  className="relative flex items-center gap-2 select-none group/header cursor-pointer"
                   onClick={(e) => {
-                    // Modifier clicks select columns instead of sorting:
-                    // Cmd/Ctrl toggles one, Shift range-selects from the anchor.
-                    if (e.metaKey || e.ctrlKey || e.shiftKey) {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      handleColumnHeaderSelectRef.current(index, e);
-                      return;
-                    }
-                    if (onSort) onSort(colName);
+                    // Plain click selects the column, Cmd/Ctrl toggles it,
+                    // Shift range-selects from the anchor.
+                    e.preventDefault();
+                    e.stopPropagation();
+                    handleColumnHeaderSelectRef.current(index, e);
                   }}
-                  onKeyDown={(e) => { if (onSort && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); onSort(colName); } }}
-                  title={
-                    // Suppress the native sort-hint title while the type tooltip
-                    // is shown, to avoid two overlapping tooltips on hover.
-                    colType
-                      ? undefined
-                      : onSort
-                        ? displaySortState === "none"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleColumnHeaderSelectRef.current(
+                        index,
+                        e as unknown as React.MouseEvent,
+                      );
+                    }
+                  }}
+                  title={colType ? undefined : t("dataGrid.selectColumn")}
+                >
+                  <span>{colName}</span>
+                  {onSort && (
+                    <button
+                      type="button"
+                      className="flex flex-col items-center justify-center cursor-pointer"
+                      aria-label={
+                        displaySortState === "none"
                           ? t("dataGrid.sortByAsc", { col: colName })
                           : displaySortState === "asc"
                             ? t("dataGrid.sortByDesc", { col: colName })
                             : t("dataGrid.clearSort")
-                        : undefined
-                  }
-                >
-                  <span>{colName}</span>
-                  {onSort && (
-                    <span className="flex flex-col items-center justify-center">
+                      }
+                      title={
+                        // Suppress the native sort-hint title while the type
+                        // tooltip is shown, to avoid two overlapping tooltips.
+                        colType
+                          ? undefined
+                          : displaySortState === "none"
+                            ? t("dataGrid.sortByAsc", { col: colName })
+                            : displaySortState === "asc"
+                              ? t("dataGrid.sortByDesc", { col: colName })
+                              : t("dataGrid.clearSort")
+                      }
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        onSort(colName);
+                      }}
+                    >
                       {displaySortState === "asc" && (
                         <ArrowUp size={14} className="text-blue-400" />
                       )}
@@ -1290,7 +1314,7 @@ export const DataGrid = React.memo(
                           className="text-secondary/60 opacity-50 group-hover/header:opacity-100 transition-opacity"
                         />
                       )}
-                    </span>
+                    </button>
                   )}
                   {colType && (
                     <span
@@ -1987,7 +2011,6 @@ export const DataGrid = React.memo(
     const handleGridKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLDivElement>) => {
         if (editingCellRef.current) return;
-        if (e.metaKey || e.ctrlKey || e.altKey) return;
 
         // Let anything that handles keys itself keep them: text inputs, and the
         // focusable controls living inside cells and headers (FK/BLOB buttons,
@@ -2004,12 +2027,119 @@ export const DataGrid = React.memo(
         const totalCols = columns.length;
         if (totalRows === 0) return;
 
+        // Spreadsheet-style selection shortcuts, relative to the focused cell
+        // (or the current cell range): Shift+Space selects the row(s),
+        // Ctrl/Cmd+Space selects the column(s). Ctrl/Cmd+Shift+Space is an
+        // alternative for column selection, because plain Ctrl+Space is often
+        // swallowed before it reaches the app (IME toggle on Linux, Spotlight
+        // on macOS). Both convert the cell range into a row/column selection,
+        // since the three are mutually exclusive.
+        if (e.key === " " && focusedCell && !e.altKey) {
+          const isColumnSelect = e.ctrlKey || e.metaKey;
+          const isRowSelect = e.shiftKey && !isColumnSelect;
+          if (isColumnSelect) {
+            e.preventDefault();
+            const from = cellRange?.minCol ?? focusedCell.colIndex;
+            const to = cellRange?.maxCol ?? focusedCell.colIndex;
+            setSelectedColIndices(new Set(calculateSelectionRange(from, to)));
+            setLastSelectedColIndex(focusedCell.colIndex);
+            updateSelection(new Set());
+            setCellRange(null);
+            return;
+          }
+          if (isRowSelect) {
+            e.preventDefault();
+            const from = cellRange?.minRow ?? focusedCell.rowIndex;
+            const to = cellRange?.maxRow ?? focusedCell.rowIndex;
+            updateSelection(new Set(calculateSelectionRange(from, to)));
+            setLastSelectedRowIndex(focusedCell.rowIndex);
+            setSelectedColIndices(new Set());
+            setCellRange(null);
+            return;
+          }
+        }
+
+        // Ctrl/Cmd+Arrow jumps the focused cell to the grid edge, Ctrl/Cmd+
+        // Shift+Arrow extends the range to the edge, Ctrl/Cmd+Home/End go to
+        // the first/last cell (spreadsheet semantics). The event is stopped so
+        // the window-level pagination shortcuts (Ctrl+←/→) don't fire on top;
+        // they still work when no cell is focused.
+        if ((e.ctrlKey || e.metaKey) && !e.altKey && focusedCell) {
+          if (RANGE_EXTEND_KEYS.has(e.key)) {
+            e.preventDefault();
+            e.stopPropagation();
+            const key = e.key as RangeExtendKey;
+            if (e.shiftKey) {
+              const next = extendCellRange(
+                focusedCell,
+                cellRange,
+                key,
+                totalRows,
+                totalCols,
+                true,
+              );
+              if (next) {
+                setCellRange(next.range);
+                updateSelection(new Set());
+                setSelectedColIndices(new Set());
+                rowVirtualizer.scrollToIndex(next.cursor.rowIndex, {
+                  align: "auto",
+                });
+              }
+            } else {
+              const next = moveCellPosition(
+                focusedCell,
+                key,
+                totalRows,
+                totalCols,
+                true,
+              );
+              setCellRange(null);
+              setFocusedCell(next);
+            }
+            return;
+          }
+          if ((e.key === "Home" || e.key === "End") && !e.shiftKey) {
+            e.preventDefault();
+            e.stopPropagation();
+            setCellRange(null);
+            setFocusedCell(
+              e.key === "Home"
+                ? { rowIndex: 0, colIndex: 0 }
+                : { rowIndex: totalRows - 1, colIndex: totalCols - 1 },
+            );
+            return;
+          }
+        }
+
+        if (e.metaKey || e.ctrlKey || e.altKey) return;
         if (!NAVIGATION_KEYS.has(e.key)) return;
         e.preventDefault();
 
         // First keystroke inside an unfocused grid enters at the top-left cell.
         if (!focusedCell) {
           setFocusedCell({ rowIndex: 0, colIndex: 0 });
+          return;
+        }
+
+        // Shift+Arrow grows/shrinks a rectangular range from the focused
+        // anchor, moving the opposite corner one step (Google Sheets style).
+        if (e.shiftKey && RANGE_EXTEND_KEYS.has(e.key)) {
+          const next = extendCellRange(
+            focusedCell,
+            cellRange,
+            e.key as RangeExtendKey,
+            totalRows,
+            totalCols,
+          );
+          if (next) {
+            setCellRange(next.range);
+            updateSelection(new Set());
+            setSelectedColIndices(new Set());
+            rowVirtualizer.scrollToIndex(next.cursor.rowIndex, {
+              align: "auto",
+            });
+          }
           return;
         }
 
@@ -2082,6 +2212,7 @@ export const DataGrid = React.memo(
       },
       [
         focusedCell,
+        cellRange,
         mergedRows,
         columns,
         editableCellValue,
@@ -2089,6 +2220,8 @@ export const DataGrid = React.memo(
         maskedColIndices,
         revealedColIndices,
         revealedCells,
+        updateSelection,
+        rowVirtualizer,
       ],
     );
 

--- a/src/config/shortcuts.json
+++ b/src/config/shortcuts.json
@@ -100,6 +100,56 @@
     "overridable": true
   },
   {
+    "id": "extend_cell_range",
+    "category": "data_grid",
+    "defaultMac": "Shift+↑↓←→",
+    "defaultWin": "Shift+↑↓←→",
+    "macMatch": { "shiftKey": true, "key": "ArrowDown" },
+    "winMatch": { "shiftKey": true, "key": "ArrowDown" },
+    "i18nKey": "settings.shortcuts.extendCellRange",
+    "overridable": false
+  },
+  {
+    "id": "jump_to_edge",
+    "category": "data_grid",
+    "defaultMac": "⌘+↑↓←→",
+    "defaultWin": "Ctrl+↑↓←→",
+    "macMatch": { "metaKey": true, "key": "ArrowDown" },
+    "winMatch": { "ctrlKey": true, "key": "ArrowDown" },
+    "i18nKey": "settings.shortcuts.jumpToEdge",
+    "overridable": false
+  },
+  {
+    "id": "extend_cell_range_to_edge",
+    "category": "data_grid",
+    "defaultMac": "⌘+Shift+↑↓←→",
+    "defaultWin": "Ctrl+Shift+↑↓←→",
+    "macMatch": { "metaKey": true, "shiftKey": true, "key": "ArrowDown" },
+    "winMatch": { "ctrlKey": true, "shiftKey": true, "key": "ArrowDown" },
+    "i18nKey": "settings.shortcuts.extendCellRangeToEdge",
+    "overridable": false
+  },
+  {
+    "id": "select_row",
+    "category": "data_grid",
+    "defaultMac": "Shift+Space",
+    "defaultWin": "Shift+Space",
+    "macMatch": { "shiftKey": true, "key": " " },
+    "winMatch": { "shiftKey": true, "key": " " },
+    "i18nKey": "settings.shortcuts.selectRow",
+    "overridable": false
+  },
+  {
+    "id": "select_column",
+    "category": "data_grid",
+    "defaultMac": "⌘+Space / ⌘+Shift+Space",
+    "defaultWin": "Ctrl+Space / Ctrl+Shift+Space",
+    "macMatch": { "metaKey": true, "key": " " },
+    "winMatch": { "ctrlKey": true, "key": " " },
+    "i18nKey": "settings.shortcuts.selectColumn",
+    "overridable": false
+  },
+  {
     "id": "tab_switcher",
     "category": "editor",
     "defaultMac": "Ctrl+Tab",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -774,7 +774,12 @@
       "commandPaletteActions": "Aktionen suchen",
       "triggerSuggestions": "Vorschläge anzeigen",
       "formatSql": "SQL formatieren",
-      "refreshTable": "Tabelle aktualisieren"
+      "refreshTable": "Tabelle aktualisieren",
+      "extendCellRange": "Zellbereich erweitern",
+      "jumpToEdge": "Zum Rand des Rasters springen",
+      "extendCellRangeToEdge": "Zellbereich bis zum Rand erweitern",
+      "selectRow": "Zeile auswählen",
+      "selectColumn": "Spalte auswählen"
     },
     "aiActivity": "KI-Aktivität",
     "backup": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -817,7 +817,12 @@
       "commandPaletteActions": "Search actions",
       "triggerSuggestions": "Trigger suggestions",
       "formatSql": "Format SQL",
-      "refreshTable": "Refresh table"
+      "refreshTable": "Refresh table",
+      "extendCellRange": "Extend cell range",
+      "jumpToEdge": "Jump to grid edge",
+      "extendCellRangeToEdge": "Extend cell range to edge",
+      "selectRow": "Select row",
+      "selectColumn": "Select column"
     },
     "aiActivity": "AI Activity",
     "backup": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -799,7 +799,12 @@
       "commandPaletteActions": "Buscar acciones",
       "triggerSuggestions": "Mostrar sugerencias",
       "formatSql": "Formatear SQL",
-      "refreshTable": "Actualizar tabla"
+      "refreshTable": "Actualizar tabla",
+      "extendCellRange": "Extender rango de celdas",
+      "jumpToEdge": "Saltar al borde de la cuadrícula",
+      "extendCellRangeToEdge": "Extender rango hasta el borde",
+      "selectRow": "Seleccionar fila",
+      "selectColumn": "Seleccionar columna"
     },
     "aiActivity": "Actividad IA",
     "backup": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -808,7 +808,12 @@
       "commandPaletteActions": "Rechercher des actions",
       "triggerSuggestions": "Afficher les suggestions",
       "formatSql": "Formater SQL",
-      "refreshTable": "Actualiser la table"
+      "refreshTable": "Actualiser la table",
+      "extendCellRange": "Étendre la plage de cellules",
+      "jumpToEdge": "Aller au bord de la grille",
+      "extendCellRangeToEdge": "Étendre la plage jusqu'au bord",
+      "selectRow": "Sélectionner la ligne",
+      "selectColumn": "Sélectionner la colonne"
     },
     "aiActivity": "Activité IA",
     "backup": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -799,7 +799,12 @@
       "commandPaletteActions": "Cerca azioni",
       "triggerSuggestions": "Mostra suggerimenti",
       "formatSql": "Formatta SQL",
-      "refreshTable": "Aggiorna tabella"
+      "refreshTable": "Aggiorna tabella",
+      "extendCellRange": "Estendi intervallo di celle",
+      "jumpToEdge": "Salta al bordo della griglia",
+      "extendCellRangeToEdge": "Estendi intervallo fino al bordo",
+      "selectRow": "Seleziona riga",
+      "selectColumn": "Seleziona colonna"
     },
     "aiActivity": "Attività AI",
     "backup": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -788,7 +788,12 @@
       "commandPaletteActions": "アクションを検索",
       "triggerSuggestions": "候補を表示",
       "formatSql": "SQLをフォーマット",
-      "refreshTable": "テーブルを更新"
+      "refreshTable": "テーブルを更新",
+      "extendCellRange": "セル範囲を拡張",
+      "jumpToEdge": "グリッドの端へ移動",
+      "extendCellRangeToEdge": "セル範囲を端まで拡張",
+      "selectRow": "行を選択",
+      "selectColumn": "列を選択"
     },
     "aiActivity": "AI アクティビティ",
     "backup": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -749,6 +749,11 @@
       "pasteImportClipboard": "클립보드에서 가져오기",
       "quickNavigator": "빠른 탐색기",
       "formatSql": "SQL 포맷",
+      "extendCellRange": "셀 범위 확장",
+      "jumpToEdge": "그리드 가장자리로 이동",
+      "extendCellRangeToEdge": "셀 범위를 가장자리까지 확장",
+      "selectRow": "행 선택",
+      "selectColumn": "열 선택",
       "commandPaletteActions": "작업 검색"
     },
     "aiActivity": "AI 활동",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -787,7 +787,12 @@
       "commandPaletteActions": "Buscar ações",
       "triggerSuggestions": "Acionar sugestões",
       "formatSql": "Formatar SQL",
-      "refreshTable": "Atualizar tabela"
+      "refreshTable": "Atualizar tabela",
+      "extendCellRange": "Estender intervalo de células",
+      "jumpToEdge": "Ir para a borda da grade",
+      "extendCellRangeToEdge": "Estender intervalo até a borda",
+      "selectRow": "Selecionar linha",
+      "selectColumn": "Selecionar coluna"
     },
     "aiActivity": "Atividade de IA",
     "backup": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -767,7 +767,12 @@
       "commandPaletteActions": "Поиск действий",
       "triggerSuggestions": "Показать подсказки",
       "formatSql": "Форматировать SQL",
-      "refreshTable": "Обновить таблицу"
+      "refreshTable": "Обновить таблицу",
+      "extendCellRange": "Расширить диапазон ячеек",
+      "jumpToEdge": "Перейти к краю таблицы",
+      "extendCellRangeToEdge": "Расширить диапазон до края",
+      "selectRow": "Выделить строку",
+      "selectColumn": "Выделить столбец"
     },
     "aiActivity": "Активность AI",
     "backup": {

--- a/src/i18n/locales/tl.json
+++ b/src/i18n/locales/tl.json
@@ -804,6 +804,11 @@
       "pasteImportClipboard": "I-import mula sa Clipboard",
       "quickNavigator": "Quick Navigator",
       "formatSql": "I-format ang SQL",
+      "extendCellRange": "Palawakin ang cell range",
+      "jumpToEdge": "Tumalon sa gilid ng grid",
+      "extendCellRangeToEdge": "Palawakin ang range hanggang sa gilid",
+      "selectRow": "Piliin ang row",
+      "selectColumn": "Piliin ang column",
       "commandPaletteActions": "Maghanap ng mga aksyon"
     },
     "aiActivity": "AI Activity",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -737,7 +737,12 @@
       "commandPaletteActions": "搜索操作",
       "triggerSuggestions": "触发建议",
       "formatSql": "格式化 SQL",
-      "refreshTable": "刷新表格"
+      "refreshTable": "刷新表格",
+      "extendCellRange": "扩展单元格范围",
+      "jumpToEdge": "跳转到网格边缘",
+      "extendCellRangeToEdge": "扩展单元格范围至边缘",
+      "selectRow": "选择行",
+      "selectColumn": "选择列"
     },
     "aiActivity": "AI 活动",
     "backup": {

--- a/src/utils/dataGrid.ts
+++ b/src/utils/dataGrid.ts
@@ -194,6 +194,107 @@ export function calculateSelectionRange(
   return range;
 }
 
+/** Normalized rectangular cell range (inclusive bounds). */
+export interface CellRangeRect {
+  minRow: number;
+  maxRow: number;
+  minCol: number;
+  maxCol: number;
+}
+
+export interface CellPosition {
+  rowIndex: number;
+  colIndex: number;
+}
+
+/** Arrow keys that extend a cell range when pressed with Shift. */
+export type RangeExtendKey =
+  | "ArrowUp"
+  | "ArrowDown"
+  | "ArrowLeft"
+  | "ArrowRight";
+
+/**
+ * Returns the corner of a range opposite to the anchor — the cell that moves
+ * when the range is extended with Shift+Arrow (Google Sheets semantics: the
+ * anchor stays put, the active corner walks).
+ */
+export function getRangeCursor(
+  anchor: CellPosition,
+  range: CellRangeRect | null,
+): CellPosition {
+  if (!range) return anchor;
+  return {
+    rowIndex: anchor.rowIndex === range.minRow ? range.maxRow : range.minRow,
+    colIndex: anchor.colIndex === range.minCol ? range.maxCol : range.minCol,
+  };
+}
+
+/** Builds the normalized rectangle spanning two cells. */
+export function buildCellRange(
+  a: CellPosition,
+  b: CellPosition,
+): CellRangeRect {
+  return {
+    minRow: Math.min(a.rowIndex, b.rowIndex),
+    maxRow: Math.max(a.rowIndex, b.rowIndex),
+    minCol: Math.min(a.colIndex, b.colIndex),
+    maxCol: Math.max(a.colIndex, b.colIndex),
+  };
+}
+
+/**
+ * Moves a cell position in the direction of an arrow key, clamped to the grid.
+ * With `toEdge` the position jumps straight to the first/last row or column
+ * (spreadsheet Ctrl+Arrow); otherwise it moves a single step.
+ */
+export function moveCellPosition(
+  pos: CellPosition,
+  key: RangeExtendKey,
+  totalRows: number,
+  totalCols: number,
+  toEdge = false,
+): CellPosition {
+  let { rowIndex, colIndex } = pos;
+  switch (key) {
+    case "ArrowUp":
+      rowIndex = toEdge ? 0 : Math.max(0, rowIndex - 1);
+      break;
+    case "ArrowDown":
+      rowIndex = toEdge ? totalRows - 1 : Math.min(totalRows - 1, rowIndex + 1);
+      break;
+    case "ArrowLeft":
+      colIndex = toEdge ? 0 : Math.max(0, colIndex - 1);
+      break;
+    case "ArrowRight":
+      colIndex = toEdge ? totalCols - 1 : Math.min(totalCols - 1, colIndex + 1);
+      break;
+  }
+  return { rowIndex, colIndex };
+}
+
+/**
+ * Extends (or shrinks) a cell range from its moving corner while keeping the
+ * anchor fixed — one step by default, straight to the grid edge with `toEdge`
+ * (Shift+Arrow vs Ctrl+Shift+Arrow). Returns the new range and cursor, or
+ * null when the cursor is already at the grid edge in that direction.
+ */
+export function extendCellRange(
+  anchor: CellPosition,
+  range: CellRangeRect | null,
+  key: RangeExtendKey,
+  totalRows: number,
+  totalCols: number,
+  toEdge = false,
+): { range: CellRangeRect; cursor: CellPosition } | null {
+  const cursor = getRangeCursor(anchor, range);
+  const next = moveCellPosition(cursor, key, totalRows, totalCols, toEdge);
+  if (next.rowIndex === cursor.rowIndex && next.colIndex === cursor.colIndex) {
+    return null;
+  }
+  return { range: buildCellRange(anchor, next), cursor: next };
+}
+
 /**
  * Toggles a value in a Set (adds if not present, removes if present)
  * @param set - The Set to modify

--- a/tests/components/ui/DataGrid.test.tsx
+++ b/tests/components/ui/DataGrid.test.tsx
@@ -193,13 +193,90 @@ describe("DataGrid keyboard navigation", () => {
     expect(cellAt(container, 1, 0)).toHaveClass("ring-2");
   });
 
-  it("ignores navigation keys while a modifier is held", () => {
+  it("ignores navigation keys while Alt is held", () => {
+    const { container } = renderGrid();
+
+    fireEvent.click(cellAt(container, 0, 0));
+    fireEvent.keyDown(gridOf(container), { key: "ArrowDown", altKey: true });
+
+    expect(cellAt(container, 0, 0)).toHaveClass("ring-2");
+  });
+
+  it("Cmd/Ctrl+Arrow jumps the focused cell to the grid edge", () => {
     const { container } = renderGrid();
 
     fireEvent.click(cellAt(container, 0, 0));
     fireEvent.keyDown(gridOf(container), { key: "ArrowDown", metaKey: true });
+    expect(cellAt(container, 2, 0)).toHaveClass("ring-2");
 
+    fireEvent.keyDown(gridOf(container), { key: "ArrowRight", ctrlKey: true });
+    expect(cellAt(container, 2, 1)).toHaveClass("ring-2");
+
+    fireEvent.keyDown(gridOf(container), { key: "Home", ctrlKey: true });
     expect(cellAt(container, 0, 0)).toHaveClass("ring-2");
+  });
+
+  it("Cmd/Ctrl+Arrow without a focused cell is left to the page-level shortcuts", () => {
+    const { container } = renderGrid();
+
+    fireEvent.keyDown(gridOf(container), { key: "ArrowRight", ctrlKey: true });
+
+    expect(container.querySelector("td.ring-2")).toBeNull();
+  });
+
+  it("Shift+Arrow extends a cell range from the focused anchor", () => {
+    const { container } = renderGrid();
+
+    fireEvent.click(cellAt(container, 0, 0));
+    fireEvent.keyDown(gridOf(container), { key: "ArrowDown", shiftKey: true });
+    fireEvent.keyDown(gridOf(container), { key: "ArrowRight", shiftKey: true });
+
+    expect(cellAt(container, 0, 0)).toHaveClass("bg-blue-500/15");
+    expect(cellAt(container, 1, 1)).toHaveClass("bg-blue-500/15");
+    expect(cellAt(container, 2, 0)).not.toHaveClass("bg-blue-500/15");
+
+    // Ctrl+Shift+Arrow extends to the edge.
+    fireEvent.keyDown(gridOf(container), {
+      key: "ArrowDown",
+      shiftKey: true,
+      ctrlKey: true,
+    });
+    expect(cellAt(container, 2, 1)).toHaveClass("bg-blue-500/15");
+  });
+
+  it("Shift+Space selects the row(s) and Cmd/Ctrl+Space the column(s) of the focused cell", () => {
+    const onSelectionChange = vi.fn();
+    const { container } = render(
+      <DataGrid
+        columns={["id", "name"]}
+        data={[
+          [1, "Alice"],
+          [2, "Bob"],
+        ]}
+        selectedRows={new Set()}
+        onSelectionChange={onSelectionChange}
+        readonly
+      />,
+    );
+
+    fireEvent.click(cellAt(container, 1, 0));
+    fireEvent.keyDown(gridOf(container), { key: " ", shiftKey: true });
+    expect(onSelectionChange).toHaveBeenLastCalledWith(new Set([1]));
+
+    fireEvent.keyDown(gridOf(container), { key: " ", ctrlKey: true });
+    expect(container.querySelectorAll("th")[1]).toHaveClass("bg-blue-500/20");
+    expect(container.querySelectorAll("th")[2]).not.toHaveClass(
+      "bg-blue-500/20",
+    );
+
+    // Ctrl+Shift+Space is the IME-safe alternative for column selection.
+    fireEvent.click(cellAt(container, 1, 1));
+    fireEvent.keyDown(gridOf(container), {
+      key: " ",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    expect(container.querySelectorAll("th")[2]).toHaveClass("bg-blue-500/20");
   });
 
   it("leaves keys to focusable controls inside the grid", () => {
@@ -588,7 +665,7 @@ describe("DataGrid column selection", () => {
     return { ...utils, onSort };
   };
 
-  it("Cmd/Ctrl+click selects a column without sorting; plain click still sorts", () => {
+  it("Cmd/Ctrl+click toggles a column without sorting", () => {
     const { container, onSort } = renderGrid();
 
     fireEvent.click(screen.getByText("id"), { metaKey: true });
@@ -596,8 +673,28 @@ describe("DataGrid column selection", () => {
     expect(onSort).not.toHaveBeenCalled();
     expect(container.querySelectorAll("th")[1]).toHaveClass("bg-blue-500/20");
 
+    fireEvent.click(screen.getByText("id"), { metaKey: true });
+    expect(container.querySelectorAll("th")[1]).not.toHaveClass(
+      "bg-blue-500/20",
+    );
+  });
+
+  it("plain header click selects a single column; sorting is on the sort button", () => {
+    const { container, onSort } = renderGrid();
+
+    fireEvent.click(screen.getByText("id"));
+    expect(onSort).not.toHaveBeenCalled();
+    expect(container.querySelectorAll("th")[1]).toHaveClass("bg-blue-500/20");
+
+    // Plain click replaces the selection instead of adding to it.
     fireEvent.click(screen.getByText("name"));
-    expect(onSort).toHaveBeenCalledWith("name");
+    expect(container.querySelectorAll("th")[1]).not.toHaveClass(
+      "bg-blue-500/20",
+    );
+    expect(container.querySelectorAll("th")[2]).toHaveClass("bg-blue-500/20");
+
+    fireEvent.click(screen.getAllByLabelText("dataGrid.sortByAsc")[0]);
+    expect(onSort).toHaveBeenCalledWith("id");
   });
 
   it("copies only the selected columns with Cmd/Ctrl+C", async () => {

--- a/tests/utils/dataGrid.test.ts
+++ b/tests/utils/dataGrid.test.ts
@@ -13,6 +13,10 @@ import {
   parsePasteMatrix,
   stripHeaderRow,
   computePasteTargets,
+  getRangeCursor,
+  buildCellRange,
+  extendCellRange,
+  moveCellPosition,
   type ColumnDisplayInfo,
   type CellClassParams,
 } from '../../src/utils/dataGrid';
@@ -909,6 +913,126 @@ describe('dataGrid utils', () => {
       expect(
         computePasteTargets([], { rowIndex: 0, colIndex: 0 }, 10, 10),
       ).toEqual([]);
+    });
+  });
+
+  describe('getRangeCursor', () => {
+    it('should return the anchor when there is no range', () => {
+      expect(getRangeCursor({ rowIndex: 2, colIndex: 3 }, null)).toEqual({
+        rowIndex: 2,
+        colIndex: 3,
+      });
+    });
+
+    it('should return the corner opposite to the anchor', () => {
+      const range = { minRow: 1, maxRow: 4, minCol: 2, maxCol: 5 };
+      expect(getRangeCursor({ rowIndex: 1, colIndex: 2 }, range)).toEqual({ rowIndex: 4, colIndex: 5 });
+      expect(getRangeCursor({ rowIndex: 4, colIndex: 5 }, range)).toEqual({ rowIndex: 1, colIndex: 2 });
+      expect(getRangeCursor({ rowIndex: 1, colIndex: 5 }, range)).toEqual({ rowIndex: 4, colIndex: 2 });
+      expect(getRangeCursor({ rowIndex: 4, colIndex: 2 }, range)).toEqual({ rowIndex: 1, colIndex: 5 });
+    });
+
+    it('should return the anchor for a single-cell range', () => {
+      const range = { minRow: 3, maxRow: 3, minCol: 3, maxCol: 3 };
+      expect(getRangeCursor({ rowIndex: 3, colIndex: 3 }, range)).toEqual({ rowIndex: 3, colIndex: 3 });
+    });
+  });
+
+  describe('buildCellRange', () => {
+    it('should normalize the two corners regardless of order', () => {
+      const expected = { minRow: 1, maxRow: 5, minCol: 0, maxCol: 2 };
+      expect(buildCellRange({ rowIndex: 1, colIndex: 2 }, { rowIndex: 5, colIndex: 0 })).toEqual(expected);
+      expect(buildCellRange({ rowIndex: 5, colIndex: 0 }, { rowIndex: 1, colIndex: 2 })).toEqual(expected);
+    });
+
+    it('should build a single-cell range when both corners match', () => {
+      expect(buildCellRange({ rowIndex: 2, colIndex: 2 }, { rowIndex: 2, colIndex: 2 })).toEqual({
+        minRow: 2,
+        maxRow: 2,
+        minCol: 2,
+        maxCol: 2,
+      });
+    });
+  });
+
+  describe('extendCellRange', () => {
+    const anchor = { rowIndex: 2, colIndex: 2 };
+
+    it('should start a range from the anchor when none exists', () => {
+      expect(extendCellRange(anchor, null, 'ArrowDown', 10, 10)).toEqual({
+        range: { minRow: 2, maxRow: 3, minCol: 2, maxCol: 2 },
+        cursor: { rowIndex: 3, colIndex: 2 },
+      });
+      expect(extendCellRange(anchor, null, 'ArrowLeft', 10, 10)).toEqual({
+        range: { minRow: 2, maxRow: 2, minCol: 1, maxCol: 2 },
+        cursor: { rowIndex: 2, colIndex: 1 },
+      });
+    });
+
+    it('should grow an existing range from its moving corner and keep the anchor fixed', () => {
+      const range = { minRow: 2, maxRow: 3, minCol: 2, maxCol: 2 };
+      const result = extendCellRange(anchor, range, 'ArrowRight', 10, 10);
+      expect(result).toEqual({
+        range: { minRow: 2, maxRow: 3, minCol: 2, maxCol: 3 },
+        cursor: { rowIndex: 3, colIndex: 3 },
+      });
+    });
+
+    it('should shrink the range when moving back towards the anchor', () => {
+      const range = { minRow: 2, maxRow: 4, minCol: 2, maxCol: 2 };
+      expect(extendCellRange(anchor, range, 'ArrowUp', 10, 10)).toEqual({
+        range: { minRow: 2, maxRow: 3, minCol: 2, maxCol: 2 },
+        cursor: { rowIndex: 3, colIndex: 2 },
+      });
+    });
+
+    it('should cross over the anchor to the other side', () => {
+      const range = { minRow: 2, maxRow: 3, minCol: 2, maxCol: 2 };
+      const step1 = extendCellRange(anchor, range, 'ArrowUp', 10, 10);
+      expect(step1?.range).toEqual({ minRow: 2, maxRow: 2, minCol: 2, maxCol: 2 });
+      const step2 = extendCellRange(anchor, step1!.range, 'ArrowUp', 10, 10);
+      expect(step2?.range).toEqual({ minRow: 1, maxRow: 2, minCol: 2, maxCol: 2 });
+    });
+
+    it('should return null at the grid edges', () => {
+      expect(extendCellRange({ rowIndex: 0, colIndex: 0 }, null, 'ArrowUp', 10, 10)).toBeNull();
+      expect(extendCellRange({ rowIndex: 0, colIndex: 0 }, null, 'ArrowLeft', 10, 10)).toBeNull();
+      expect(extendCellRange({ rowIndex: 9, colIndex: 9 }, null, 'ArrowDown', 10, 10)).toBeNull();
+      expect(extendCellRange({ rowIndex: 9, colIndex: 9 }, null, 'ArrowRight', 10, 10)).toBeNull();
+    });
+
+    it('should clamp when the cursor is at the edge but the anchor is not', () => {
+      const range = { minRow: 2, maxRow: 9, minCol: 2, maxCol: 2 };
+      expect(extendCellRange(anchor, range, 'ArrowDown', 10, 10)).toBeNull();
+    });
+
+    it('should extend straight to the grid edge with toEdge', () => {
+      expect(extendCellRange(anchor, null, 'ArrowDown', 10, 10, true)).toEqual({
+        range: { minRow: 2, maxRow: 9, minCol: 2, maxCol: 2 },
+        cursor: { rowIndex: 9, colIndex: 2 },
+      });
+      expect(extendCellRange(anchor, null, 'ArrowLeft', 10, 10, true)).toEqual({
+        range: { minRow: 2, maxRow: 2, minCol: 0, maxCol: 2 },
+        cursor: { rowIndex: 2, colIndex: 0 },
+      });
+    });
+  });
+
+  describe('moveCellPosition', () => {
+    const pos = { rowIndex: 3, colIndex: 3 };
+
+    it('should move one step and clamp at the edges', () => {
+      expect(moveCellPosition(pos, 'ArrowUp', 10, 10)).toEqual({ rowIndex: 2, colIndex: 3 });
+      expect(moveCellPosition(pos, 'ArrowRight', 10, 10)).toEqual({ rowIndex: 3, colIndex: 4 });
+      expect(moveCellPosition({ rowIndex: 0, colIndex: 0 }, 'ArrowUp', 10, 10)).toEqual({ rowIndex: 0, colIndex: 0 });
+      expect(moveCellPosition({ rowIndex: 9, colIndex: 9 }, 'ArrowDown', 10, 10)).toEqual({ rowIndex: 9, colIndex: 9 });
+    });
+
+    it('should jump to the edge with toEdge', () => {
+      expect(moveCellPosition(pos, 'ArrowUp', 10, 10, true)).toEqual({ rowIndex: 0, colIndex: 3 });
+      expect(moveCellPosition(pos, 'ArrowDown', 10, 10, true)).toEqual({ rowIndex: 9, colIndex: 3 });
+      expect(moveCellPosition(pos, 'ArrowLeft', 10, 10, true)).toEqual({ rowIndex: 3, colIndex: 0 });
+      expect(moveCellPosition(pos, 'ArrowRight', 10, 10, true)).toEqual({ rowIndex: 3, colIndex: 9 });
     });
   });
 });


### PR DESCRIPTION
Closes #673

## What changed

Spreadsheet-style (Google Sheets) selection shortcuts in the data grid. All of them are relative to the focused cell (single click or arrow navigation):

| Shortcut | Action |
|---|---|
| Shift+Arrow | extend a rectangular cell range by one step (anchor stays fixed, the opposite corner moves) |
| Ctrl/Cmd+Arrow | jump the focused cell to the grid edge |
| Ctrl/Cmd+Shift+Arrow | extend the range to the grid edge |
| Ctrl/Cmd+Home / End | first / last cell |
| Shift+Space | select the row(s) of the focused cell or of the current range |
| Ctrl/Cmd+Space, or Ctrl/Cmd+Shift+Space | select the column(s) of the focused cell or of the current range |

Ctrl+Shift+Space is offered as an alternative because plain Ctrl+Space is often consumed before it reaches the app (ibus/fcitx on Linux, Spotlight on macOS).

Header changes:

- A plain click on a column header now selects that column (replacing the selection). Ctrl/Cmd+click still toggles, Shift+click still range-selects.
- Sorting moves to the sort icon next to the column name, which is now a real `<button>` with the sort aria-label/title. It is still revealed on hover as before.

Row, column and cell-range selection stay mutually exclusive, so Ctrl+C keeps unambiguous copy semantics. The focused cell is kept after Shift/Ctrl+Space so shortcuts can be chained (for example Shift+Down three times, then Shift+Space, selects four rows).

Other:

- Range logic extracted into pure helpers in `src/utils/dataGrid.ts` (`buildCellRange`, `getRangeCursor`, `moveCellPosition`, `extendCellRange`); `handleCellClick` reuses `buildCellRange`.
- New bindings listed in the Shortcuts settings tab (`shortcuts.json`, non overridable), with strings in all 11 locales.

## Behaviour changes to be aware of

1. Ctrl+Left/Right with a focused cell no longer paginates: the grid stops the event and jumps to the edge. The `next_page` / `prev_page` shortcuts still work when no cell is focused, and from the pagination buttons. If we prefer to avoid the overlap entirely, the pagination defaults could move to another combination (they are user overridable).
2. Plain header click no longer sorts; sorting is on the icon. The existing test asserting "plain click still sorts" was replaced accordingly.

## Verification

- `pnpm test --run`: 235 files, 3892 tests passing (new unit tests for the range helpers and component tests for every new shortcut and the header click behaviour)
- `pnpm lint`: 0 errors (one pre-existing warning in `ThemeProvider.tsx`, untouched)
- `pnpm build`: ok

Manual testing still needed on Linux with an IME configured and on macOS, to confirm the Ctrl+Space fallback story.
