### PR TITLE
fix(notebook): address bugs in the frontend part of notebook feature

### DIFF
--- a/src/components/notebook/AddCellButton.tsx
+++ b/src/components/notebook/AddCellButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Plus } from "lucide-react";
 
@@ -10,6 +10,17 @@ interface AddCellButtonProps {
 export function AddCellButton({ onAddSql, onAddMarkdown }: AddCellButtonProps) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
+  const [openUpward, setOpenUpward] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const handleToggle = () => {
+    if (!isOpen && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      const spaceBelow = window.innerHeight - rect.bottom;
+      setOpenUpward(spaceBelow < 90);
+    }
+    setIsOpen((prev) => !prev);
+  };
 
   return (
     <div className="relative flex items-center justify-center h-8 group">
@@ -18,8 +29,9 @@ export function AddCellButton({ onAddSql, onAddMarkdown }: AddCellButtonProps) {
 
       {/* Add button */}
       <button
+        ref={buttonRef}
         type="button"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={handleToggle}
         className="relative z-10 flex items-center justify-center w-6 h-6 rounded-full bg-surface-secondary text-muted hover:text-primary hover:bg-surface-tertiary opacity-0 group-hover:opacity-100 transition-all"
       >
         <Plus size={14} />
@@ -32,7 +44,11 @@ export function AddCellButton({ onAddSql, onAddMarkdown }: AddCellButtonProps) {
             className="fixed inset-0 z-10"
             onClick={() => setIsOpen(false)}
           />
-          <div className="absolute top-full mt-1 z-20 bg-elevated border border-default rounded-lg shadow-lg overflow-hidden">
+          <div
+            className={`absolute z-20 bg-elevated border border-default rounded-lg shadow-lg overflow-hidden ${
+              openUpward ? "bottom-full mb-1" : "top-full mt-1"
+            }`}
+          >
           <button
             type="button"
             onClick={() => {

--- a/src/components/notebook/NotebookView.tsx
+++ b/src/components/notebook/NotebookView.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
+import { flushSync } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { save, open } from "@tauri-apps/plugin-dialog";
@@ -272,15 +273,41 @@ export function NotebookView({
     [updateNotebook],
   );
 
+  const focusCell = useCallback((cellId: string) => {
+    const tryFocus = (attempts: number) => {
+      const el = cellRefsMap.current.get(cellId);
+      if (!el) {
+        if (attempts < 10) requestAnimationFrame(() => tryFocus(attempts + 1));
+        return;
+      }
+      const monacoTextarea = el.querySelector<HTMLTextAreaElement>(".monaco-editor textarea");
+      if (monacoTextarea) {
+        monacoTextarea.focus();
+        return;
+      }
+      const textarea = el.querySelector<HTMLTextAreaElement>("textarea");
+      if (textarea) {
+        textarea.focus();
+        return;
+      }
+      if (attempts < 10) requestAnimationFrame(() => tryFocus(attempts + 1));
+    };
+    requestAnimationFrame(() => tryFocus(0));
+  }, []);
+
   const addCell = useCallback(
     (type: NotebookCellType, afterIndex?: number): string => {
       const newCells = addCellToCells(cellsRef.current, type, afterIndex);
       const insertAt = afterIndex !== undefined ? afterIndex + 1 : newCells.length - 1;
       const newCellId = newCells[insertAt].id;
-      updateNotebook(newCells);
+      flushSync(() => updateNotebook(newCells));
+      cellRefsMap.current
+        .get(newCellId)
+        ?.scrollIntoView({ behavior: "smooth", block: "center" });
+      focusCell(newCellId);
       return newCellId;
     },
-    [updateNotebook],
+    [updateNotebook, focusCell],
   );
 
   const deleteCell = useCallback(
@@ -678,37 +705,6 @@ export function NotebookView({
   // Cancel any in-flight auto-scroll frame if the view unmounts mid-drag.
   useEffect(() => stopAutoScroll, [stopAutoScroll]);
 
-  const scrollToBottom = useCallback(() => {
-    requestAnimationFrame(() => {
-      scrollContainerRef.current?.scrollTo({
-        top: scrollContainerRef.current.scrollHeight,
-        behavior: "smooth",
-      });
-    });
-  }, []);
-
-  const focusCell = useCallback((cellId: string) => {
-    const tryFocus = (attempts: number) => {
-      const el = cellRefsMap.current.get(cellId);
-      if (!el) {
-        if (attempts < 10) requestAnimationFrame(() => tryFocus(attempts + 1));
-        return;
-      }
-      const monacoTextarea = el.querySelector<HTMLTextAreaElement>(".monaco-editor textarea");
-      if (monacoTextarea) {
-        monacoTextarea.focus();
-        return;
-      }
-      const textarea = el.querySelector<HTMLTextAreaElement>("textarea");
-      if (textarea) {
-        textarea.focus();
-        return;
-      }
-      if (attempts < 10) requestAnimationFrame(() => tryFocus(attempts + 1));
-    };
-    requestAnimationFrame(() => tryFocus(0));
-  }, []);
-
   const scrollToCell = useCallback((cellId: string) => {
     const el = cellRefsMap.current.get(cellId);
     el?.scrollIntoView({ behavior: "smooth", block: "center" });
@@ -764,16 +760,8 @@ export function NotebookView({
   }, [updateNotebook]);
 
   const toolbarProps = {
-    onAddSqlCell: () => {
-      const id = addCell("sql");
-      scrollToBottom();
-      focusCell(id);
-    },
-    onAddMarkdownCell: () => {
-      const id = addCell("markdown");
-      scrollToBottom();
-      focusCell(id);
-    },
+    onAddSqlCell: () => addCell("sql"),
+    onAddMarkdownCell: () => addCell("markdown"),
     onRunAll: runAll,
     onExport: handleExport,
     onExportHtml: handleExportHtml,
@@ -888,16 +876,8 @@ export function NotebookView({
         )}
 
         <AddCellButton
-          onAddSql={() => {
-            const id = addCell("sql", -1);
-            scrollToCell(id);
-            focusCell(id);
-          }}
-          onAddMarkdown={() => {
-            const id = addCell("markdown", -1);
-            scrollToCell(id);
-            focusCell(id);
-          }}
+          onAddSql={() => addCell("sql", -1)}
+          onAddMarkdown={() => addCell("markdown", -1)}
         />
         {cells.map((cell, index) => (
           <div
@@ -946,16 +926,8 @@ export function NotebookView({
               }}
             />
             <AddCellButton
-              onAddSql={() => {
-                const id = addCell("sql", index);
-                scrollToCell(id);
-                focusCell(id);
-              }}
-              onAddMarkdown={() => {
-                const id = addCell("markdown", index);
-                scrollToCell(id);
-                focusCell(id);
-              }}
+              onAddSql={() => addCell("sql", index)}
+              onAddMarkdown={() => addCell("markdown", index)}
             />
             {index === cells.length - 1 &&
               showLineAt(cells.length) &&

--- a/src/components/notebook/NotebookView.tsx
+++ b/src/components/notebook/NotebookView.tsx
@@ -888,8 +888,16 @@ export function NotebookView({
         )}
 
         <AddCellButton
-          onAddSql={() => addCell("sql", -1)}
-          onAddMarkdown={() => addCell("markdown", -1)}
+          onAddSql={() => {
+            const id = addCell("sql", -1);
+            scrollToCell(id);
+            focusCell(id);
+          }}
+          onAddMarkdown={() => {
+            const id = addCell("markdown", -1);
+            scrollToCell(id);
+            focusCell(id);
+          }}
         />
         {cells.map((cell, index) => (
           <div
@@ -938,8 +946,16 @@ export function NotebookView({
               }}
             />
             <AddCellButton
-              onAddSql={() => addCell("sql", index)}
-              onAddMarkdown={() => addCell("markdown", index)}
+              onAddSql={() => {
+                const id = addCell("sql", index);
+                scrollToCell(id);
+                focusCell(id);
+              }}
+              onAddMarkdown={() => {
+                const id = addCell("markdown", index);
+                scrollToCell(id);
+                focusCell(id);
+              }}
             />
             {index === cells.length - 1 &&
               showLineAt(cells.length) &&

--- a/src/components/notebook/SqlCellEditor.tsx
+++ b/src/components/notebook/SqlCellEditor.tsx
@@ -1,4 +1,6 @@
+import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import type { OnMount } from "@monaco-editor/react";
 import { SqlEditorWrapper } from "../ui/SqlEditorWrapper";
 import { useSettings } from "../../hooks/useSettings";
 import { NotebookAiButtons } from "./NotebookAiButtons";
@@ -27,6 +29,12 @@ export function SqlCellEditor({
 }: SqlCellEditorProps) {
   const { settings } = useSettings();
   const { t } = useTranslation();
+  const [editorHeight, setEditorHeight] = useState(60);
+  const onMount: OnMount = useCallback((editor) => {
+    const sync = () => setEditorHeight(Math.max(60, editor.getContentHeight()));
+    editor.onDidContentSizeChange(sync);
+    sync();
+  }, []);
 
   return (
     <div>
@@ -37,12 +45,13 @@ export function SqlCellEditor({
         divider={false}
       />
       {!collapsed && (
-        <div className="h-[150px] relative">
+        <div className="relative" style={{ height: editorHeight }}>
           <SqlEditorWrapper
             height="100%"
             initialValue={content}
             onChange={onContentChange}
             onRun={onRun}
+            onMount={onMount}
             editorKey={`notebook-${cellId}`}
             options={{
               padding: { top: 8, bottom: 8 },


### PR DESCRIPTION
## Problem

The notebook feature has several UX issues:

1. **Add-cell dropdown clipped off-screen** — The "+" button's dropdown always opens downward (`top-full`). When the button is near the bottom of the viewport, the menu renders off-screen and is unclickable.

https://github.com/user-attachments/assets/59b3ac2f-30e7-466e-bd76-981012ec806a


2. **New cells not scrolled into view** — After adding a cell, `scrollToCell(id)` runs synchronously before React re-renders, so the new cell's DOM ref doesn't exist yet. The scroll is a silent no-op, and the user has to manually find the new cell.

https://github.com/user-attachments/assets/b2663fd7-2689-417f-90e5-0ef51bbc9144



3. **SQL editor cramped at fixed 150px** — The query editor uses a hardcoded `h-[150px]`, forcing users to scroll inside a tiny box even for short queries. This makes multi-line queries hard to read and edit compared to tools like Jupyter or Kaggle notebooks.

https://github.com/user-attachments/assets/aa1b7c11-58a9-4fb8-a79b-5bb9fb40aa99


## Fix

### Add-cell dropdown (AddCellButton.tsx)
- Measure button position via `getBoundingClientRect()` before opening
- Flip the menu upward (`bottom-full`) when viewport space below < 90px

### Scroll & focus on add (NotebookView.tsx)
- Wrap `updateNotebook` in `flushSync` so the new cell's DOM ref is registered before `addCell` returns
- Move `scrollIntoView({ block: "center" })` and `focusCell()` inside `addCell()` itself
- Remove duplicate scroll/focus calls from all 6 call sites (toolbar + between-cell buttons)
- Remove now-unused `scrollToBottom` callback

### SQL editor auto-fit (SqlCellEditor.tsx)
- Track Monaco's content height via `onDidContentSizeChange` and set the container height to match
- Editor always shows the full query — no fixed height, no scrolling needed for short/medium queries
- Minimum 60px for empty cells

## Testing
- Click "+" on the last cell near the bottom of the page → dropdown opens upward
- Add cells via toolbar and between-cell buttons → new cell scrolls to center and editor focuses
- Type a multi-line SQL query → editor grows to fit all content
- Collapse/expand cells via chevron → works as before
- Run All → works as before

https://github.com/user-attachments/assets/1efddf5e-d8b7-4e27-8467-71c0ff75353d

<img width="2408" height="900" alt="image" src="https://github.com/user-attachments/assets/391a7e0f-7926-42bc-a86d-8be2638b0b22" />

`pnpm run test -- --testPathPattern="notebook"`
<img width="2408" height="1726" alt="image" src="https://github.com/user-attachments/assets/2e3d4a21-9b89-48c8-b532-6aea89c237dc" />
