### PR TITLE
docs(plugins): correct the RPC parameter contract

### DIFF
--- a/plugins/PLUGIN_GUIDE.md
+++ b/plugins/PLUGIN_GUIDE.md
@@ -744,7 +744,7 @@ List views in a schema/database.
 
 Get the SQL definition of a view.
 
-**Params:** `{ "params": ConnectionParams, "schema": string | null, "view": string }`
+**Params:** `{ "params": ConnectionParams, "schema": string | null, "view_name": string }`
 
 **Result:** `"SELECT * FROM users WHERE active = true"`
 
@@ -754,7 +754,7 @@ Get the SQL definition of a view.
 
 Get column information for a view.
 
-**Params:** `{ "params": ConnectionParams, "schema": string | null, "view": string }`
+**Params:** `{ "params": ConnectionParams, "schema": string | null, "view_name": string }`
 
 **Result:** Same structure as `get_columns`.
 
@@ -764,7 +764,7 @@ Get column information for a view.
 
 Create a new view.
 
-**Params:** `{ "params": ConnectionParams, "schema": string | null, "name": string, "definition": string }`
+**Params:** `{ "params": ConnectionParams, "schema": string | null, "view_name": string, "definition": string }`
 
 **Result:** `null` on success, or an error.
 
@@ -774,7 +774,7 @@ Create a new view.
 
 Replace or modify an existing view.
 
-**Params:** `{ "params": ConnectionParams, "schema": string | null, "name": string, "definition": string }`
+**Params:** `{ "params": ConnectionParams, "schema": string | null, "view_name": string, "definition": string }`
 
 **Result:** `null` on success, or an error.
 
@@ -784,7 +784,7 @@ Replace or modify an existing view.
 
 Drop a view.
 
-**Params:** `{ "params": ConnectionParams, "schema": string | null, "name": string }`
+**Params:** `{ "params": ConnectionParams, "schema": string | null, "view_name": string }`
 
 **Result:** `null` on success, or an error.
 
@@ -849,7 +849,7 @@ List stored procedures and functions.
 
 Get parameters of a stored routine.
 
-**Params:** `{ "params": ConnectionParams, "schema": string | null, "routine": string }`
+**Params:** `{ "params": ConnectionParams, "schema": string | null, "routine_name": string }`
 
 **Result:**
 ```json
@@ -864,7 +864,7 @@ Get parameters of a stored routine.
 
 Get the SQL body of a stored routine.
 
-**Params:** `{ "params": ConnectionParams, "schema": string | null, "routine": string }`
+**Params:** `{ "params": ConnectionParams, "schema": string | null, "routine_name": string, "routine_type": string }`
 
 **Result:** `"BEGIN ... END"`
 
@@ -935,9 +935,10 @@ Execute a SQL query and return results.
 ```json
 {
   "params": ConnectionParams,
+  "schema": null,
   "query": "SELECT * FROM users",
-  "page": 1,
-  "page_size": 100
+  "limit": 100,
+  "page": 1
 }
 ```
 
@@ -967,11 +968,12 @@ Insert a new row into a table.
   "params": ConnectionParams,
   "schema": null,
   "table": "users",
-  "data": { "name": "Bob", "email": "bob@example.com" }
+  "data": { "name": "Bob", "email": "bob@example.com" },
+  "max_blob_size": 10485760
 }
 ```
 
-**Result:** `null` on success, or an error.
+**Result:** Number of affected rows (e.g. `1`), or an error.
 
 ---
 
@@ -979,16 +981,20 @@ Insert a new row into a table.
 
 Update a single field in a row.
 
+`pk_map` holds every primary key column of the row, so composite keys survive the
+round trip. A driver that reads a single `pk_col`/`pk_val` pair will filter on
+nothing and silently report zero updated rows.
+
 **Params:**
 ```json
 {
   "params": ConnectionParams,
   "schema": null,
   "table": "users",
-  "pk_col": "id",
-  "pk_val": 42,
+  "pk_map": { "id": 42 },
   "col_name": "name",
-  "new_val": "Robert"
+  "new_val": "Robert",
+  "max_blob_size": 10485760
 }
 ```
 
@@ -1006,8 +1012,7 @@ Delete a row from a table.
   "params": ConnectionParams,
   "schema": null,
   "table": "users",
-  "pk_col": "id",
-  "pk_val": 42
+  "pk_map": { "id": 42 }
 }
 ```
 
@@ -1156,41 +1161,41 @@ These methods generate SQL statements. Tabularis may display the SQL to the user
 
 #### `get_create_table_sql`
 
-**Params:** `{ "params": ConnectionParams, "schema": string | null, "table": string }`
+**Params:** `{ "table_name": string, "columns": ColumnDefinition[], "schema": string | null }`
 
-**Result:** `"CREATE TABLE users (...)"`
+**Result:** `["CREATE TABLE users (...)"]` — an array of statements.
 
 ---
 
 #### `get_add_column_sql`
 
-**Params:** `{ "params": ConnectionParams, "schema": string | null, "table": string, "column": ColumnDefinition }`
+**Params:** `{ "table": string, "column": ColumnDefinition, "schema": string | null }`
 
-**Result:** `"ALTER TABLE users ADD COLUMN ..."`
+**Result:** `["ALTER TABLE users ADD COLUMN ..."]` — an array of statements.
 
 ---
 
 #### `get_alter_column_sql`
 
-**Params:** `{ "params": ConnectionParams, "schema": string | null, "table": string, "column": ColumnDefinition }`
+**Params:** `{ "table": string, "old_column": ColumnDefinition, "new_column": ColumnDefinition, "schema": string | null }`
 
-**Result:** `"ALTER TABLE users MODIFY COLUMN ..."`
+**Result:** `["ALTER TABLE users MODIFY COLUMN ..."]` — an array of statements.
 
 ---
 
 #### `get_create_index_sql`
 
-**Params:** `{ "params": ConnectionParams, "schema": string | null, "table": string, "index": IndexDefinition }`
+**Params:** `{ "table": string, "index_name": string, "columns": string[], "is_unique": boolean, "schema": string | null }`
 
-**Result:** `"CREATE INDEX idx_email ON users(email)"`
+**Result:** `["CREATE INDEX idx_email ON users(email)"]` — an array of statements.
 
 ---
 
 #### `get_create_foreign_key_sql`
 
-**Params:** `{ "params": ConnectionParams, "schema": string | null, "table": string, "fk": ForeignKeyDefinition }`
+**Params:** `{ "table": string, "fk_name": string, "column": string, "ref_table": string, "ref_column": string, "on_delete": string | null, "on_update": string | null, "schema": string | null }`
 
-**Result:** `"ALTER TABLE orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id)"`
+**Result:** `["ALTER TABLE orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id)"]` — an array of statements.
 
 ---
 
@@ -1204,7 +1209,7 @@ These methods generate SQL statements. Tabularis may display the SQL to the user
 
 #### `drop_foreign_key`
 
-**Params:** `{ "params": ConnectionParams, "schema": string | null, "table": string, "constraint_name": string }`
+**Params:** `{ "params": ConnectionParams, "schema": string | null, "table": string, "fk_name": string }`
 
 **Result:** `null` on success, or an error.
 


### PR DESCRIPTION
## Problem

`plugins/PLUGIN_GUIDE.md` documents parameter names the host does not send. A plugin written against the guide reads nothing and fails without an error.

This was hit in practice: the MongoDB driver could read fields but never saved an edit. The guide says `update_record` receives `pk_col` and `pk_val`; the host sends a `pk_map` (`src-tauri/src/plugins/driver.rs`). With neither key present the driver fell back to `{"_id": null}`, matched no document and returned zero rows changed — silently. The contract changed in d8d49352 and the guide was never updated.

## Corrections

Every method aligned with `src-tauri/src/plugins/driver.rs`:

| Method | Guide said | Host sends |
|---|---|---|
| `update_record` | `pk_col`, `pk_val` | `pk_map`, `max_blob_size` |
| `delete_record` | `pk_col`, `pk_val` | `pk_map` |
| `insert_record` | — | `max_blob_size` |
| `execute_query` | `page_size` | `limit`, `schema` |
| `get_view_definition`, `get_view_columns` | `view` | `view_name` |
| `create_view`, `alter_view`, `drop_view` | `name` | `view_name` |
| `get_routine_parameters` | `routine` | `routine_name` |
| `get_routine_definition` | `routine` | `routine_name`, `routine_type` |
| `get_create_table_sql` | `params`, `table` | `table_name`, `columns` |
| `get_add_column_sql` | `params` | no `params` |
| `get_alter_column_sql` | `column` | `old_column`, `new_column` |
| `get_create_index_sql` | `index` | `index_name`, `columns`, `is_unique` |
| `get_create_foreign_key_sql` | `fk` | `fk_name`, `column`, `ref_table`, `ref_column`, `on_delete`, `on_update` |
| `drop_foreign_key` | `constraint_name` | `fk_name` |

Also corrected the documented return types: `insert_record` returns the number of affected rows, not `null`, and the five `get_*_sql` methods return an array of statements, not a single string — the host deserialises `Vec<String>`.

`update_record` now carries a note explaining why a single `pk_col`/`pk_val` pair fails silently, so the next driver does not repeat it.

## Verification

Checked with a script that extracts every `self.process.call("method", json!({...}))` from `driver.rs` and diffs the keys against the guide. Before: 16 methods with missing or wrong parameters. After: zero missing. The remaining reported extras are example keys inside `data`, `pk_map` and a `Result` block, not parameters.

The companion fix in the MongoDB driver is TabularisDB/tabularis-mongodb-plugin#8.