### PR TITLE
Remove tap step from Homebrew Cask installation documentation

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -54,7 +54,7 @@
 
 ```bash
 winget install Debba.Tabularis                                   # Windows
-brew tap TabularisDB/tabularis && brew install --cask tabularis  # macOS
+brew install --cask tabularis  # macOS
 sudo snap install tabularis                                      # Linux
 ```
 
@@ -99,7 +99,6 @@ Alternativ den Installer von der [Releases-Seite](https://github.com/TabularisDB
 ### macOS
 
 ```bash
-brew tap TabularisDB/tabularis
 brew install --cask tabularis
 ```
 

--- a/README.es.md
+++ b/README.es.md
@@ -54,7 +54,7 @@
 
 ```bash
 winget install Debba.Tabularis                                   # Windows
-brew tap TabularisDB/tabularis && brew install --cask tabularis  # macOS
+brew install --cask tabularis  # macOS
 sudo snap install tabularis                                      # Linux
 ```
 
@@ -99,7 +99,6 @@ O descarga el instalador desde la [página de Releases](https://github.com/Tabul
 ### macOS
 
 ```bash
-brew tap TabularisDB/tabularis
 brew install --cask tabularis
 ```
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -54,7 +54,7 @@
 
 ```bash
 winget install Debba.Tabularis                                   # Windows
-brew tap TabularisDB/tabularis && brew install --cask tabularis  # macOS
+brew install --cask tabularis  # macOS
 sudo snap install tabularis                                      # Linux
 ```
 
@@ -99,7 +99,6 @@ Ou téléchargez l’installateur depuis la [page Releases](https://github.com/T
 ### macOS
 
 ```bash
-brew tap TabularisDB/tabularis
 brew install --cask tabularis
 ```
 

--- a/README.it.md
+++ b/README.it.md
@@ -54,7 +54,7 @@
 
 ```bash
 winget install Debba.Tabularis                                   # Windows
-brew tap TabularisDB/tabularis && brew install --cask tabularis  # macOS
+brew install --cask tabularis  # macOS
 sudo snap install tabularis                                      # Linux
 ```
 
@@ -99,7 +99,6 @@ Oppure scarica l’installer dalla [pagina Releases](https://github.com/Tabulari
 ### macOS
 
 ```bash
-brew tap TabularisDB/tabularis
 brew install --cask tabularis
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -54,7 +54,7 @@
 
 ```bash
 winget install Debba.Tabularis                                   # Windows
-brew tap TabularisDB/tabularis && brew install --cask tabularis  # macOS
+brew install --cask tabularis  # macOS
 sudo snap install tabularis                                      # Linux
 ```
 
@@ -99,7 +99,6 @@ winget install Debba.Tabularis
 ### macOS
 
 ```bash
-brew tap TabularisDB/tabularis
 brew install --cask tabularis
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -54,7 +54,7 @@
 
 ```bash
 winget install Debba.Tabularis                                   # Windows
-brew tap TabularisDB/tabularis && brew install --cask tabularis  # macOS
+brew install --cask tabularis  # macOS
 sudo snap install tabularis                                      # Linux
 ```
 
@@ -99,7 +99,6 @@ winget install Debba.Tabularis
 ### macOS
 
 ```bash
-brew tap TabularisDB/tabularis
 brew install --cask tabularis
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 
 ```bash
 winget install Debba.Tabularis                                   # Windows
-brew tap TabularisDB/tabularis && brew install --cask tabularis  # macOS
+brew install --cask tabularis  # macOS
 sudo snap install tabularis                                      # Linux
 ```
 
@@ -148,14 +148,6 @@ Follow the on-screen instructions to complete the installation.
 ### macOS
 
 #### Homebrew (Recommended)
-
-To add our tap, run:
-
-```bash
-brew tap TabularisDB/tabularis
-```
-
-Then install:
 
 ```bash
 brew install --cask tabularis

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -57,7 +57,7 @@
 
 ```bash
 winget install Debba.Tabularis                                   # Windows
-brew tap TabularisDB/tabularis && brew install --cask tabularis  # macOS
+brew install --cask tabularis  # macOS
 sudo snap install tabularis                                      # Linux
 ```
 
@@ -149,14 +149,6 @@ Siga as instruções na tela para concluir a instalação.
 ### macOS
 
 #### Homebrew (Recomendado)
-
-Para adicionar nosso tap, execute:
-
-```bash
-brew tap TabularisDB/tabularis
-```
-
-Depois instale:
 
 ```bash
 brew install --cask tabularis

--- a/README.ru.md
+++ b/README.ru.md
@@ -54,7 +54,7 @@
 
 ```bash
 winget install Debba.Tabularis                                   # Windows
-brew tap TabularisDB/tabularis && brew install --cask tabularis  # macOS
+brew install --cask tabularis  # macOS
 sudo snap install tabularis                                      # Linux
 ```
 
@@ -99,7 +99,6 @@ winget install Debba.Tabularis
 ### macOS
 
 ```bash
-brew tap TabularisDB/tabularis
 brew install --cask tabularis
 ```
 

--- a/README.tl.md
+++ b/README.tl.md
@@ -54,7 +54,7 @@
 
 ```bash
 winget install Debba.Tabularis                                   # Windows
-brew tap TabularisDB/tabularis && brew install --cask tabularis  # macOS
+brew install --cask tabularis  # macOS
 sudo snap install tabularis                                      # Linux
 ```
 
@@ -99,7 +99,6 @@ O i-download ang installer mula sa [Releases](https://github.com/TabularisDB/tab
 ### macOS
 
 ```bash
-brew tap TabularisDB/tabularis
 brew install --cask tabularis
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,7 +54,7 @@
 
 ```bash
 winget install Debba.Tabularis                                   # Windows
-brew tap TabularisDB/tabularis && brew install --cask tabularis  # macOS
+brew install --cask tabularis  # macOS
 sudo snap install tabularis                                      # Linux
 ```
 
@@ -99,7 +99,6 @@ winget install Debba.Tabularis
 ### macOS
 
 ```bash
-brew tap TabularisDB/tabularis
 brew install --cask tabularis
 ```
 


### PR DESCRIPTION
Removes the now unnecessary `brew tap TabularisDB/tabularis` step, and lets users know that they can install the application directly with a single Homebrew command.

* Updated the Homebrew installation instructions in all language-specific `README` files (`README.md`, `README.de.md`, `README.es.md`, `README.fr.md`, `README.it.md`, `README.ja.md`, `README.ko.md`, `README.pt-BR.md`, `README.ru.md`, `README.tl.md`, `README.zh-CN.md`) to remove the `brew tap` step and use only `brew install --cask tabularis` for macOS. 

* Removed additional references and code blocks related to adding the Homebrew tap from the installation sections in all relevant `README` files. 

See https://github.com/Homebrew/homebrew-cask/pull/284179 for more details.