### PR TITLE
fix(sqlite): display UTF-8 BLOB values as text

### DIFF
--- a/src/utils/blob.ts
+++ b/src/utils/blob.ts
@@ -387,6 +387,45 @@ export function blobHexToWireFormat(
   return `BLOB:${bytes.length}:${mimeType}:${btoa(binary)}`;
 }
 
+function formatBlobTextPreview(
+  value: unknown,
+  metadata: BlobMetadata,
+): string | null {
+  if (
+    metadata.mimeType !== "application/octet-stream" ||
+    !metadata.isBase64 ||
+    metadata.isTruncated ||
+    metadata.size > BLOB_INLINE_HEX_LIMIT_BYTES
+  ) {
+    return null;
+  }
+
+  try {
+    const payload = extractBase64Payload(value);
+    const bytes = blobPayloadToBytes(payload, true);
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+
+    // Valid UTF-8 alone is not enough to classify binary data as text.
+    const hasBinaryControlCharacter = Array.from(text).some((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return (
+        codePoint <= 0x08 ||
+        codePoint === 0x0b ||
+        codePoint === 0x0c ||
+        (codePoint >= 0x0e && codePoint <= 0x1f) ||
+        (codePoint >= 0x7f && codePoint <= 0x9f)
+      );
+    });
+    if (hasBinaryControlCharacter) {
+      return null;
+    }
+
+    return text;
+  } catch {
+    return null;
+  }
+}
+
 function formatBlobHexPreview(
   value: unknown,
   metadata: BlobMetadata,
@@ -414,7 +453,8 @@ function formatBlobHexPreview(
 
 /**
  * Formats a BLOB value for display in the DataGrid.
- * Small generic binary values use a compact hex preview. Recognized file types
+ * Complete generic BLOBs containing printable UTF-8 are displayed as text.
+ * Other small binary values use a compact hex preview. Recognized file types
  * and blobs that require fetching retain their MIME type and size metadata.
  */
 export function formatBlobValue(value: unknown, dataType: string): string {
@@ -429,6 +469,7 @@ export function formatBlobValue(value: unknown, dataType: string): string {
   }
 
   return (
+    formatBlobTextPreview(value, metadata) ??
     formatBlobHexPreview(value, metadata) ??
     `${metadata.mimeType} (${metadata.formattedSize})`
   );

--- a/tests/utils/blob.test.ts
+++ b/tests/utils/blob.test.ts
@@ -160,14 +160,31 @@ describe("blob utilities", () => {
       expect(formatBlobValue(123, "INTEGER")).toBe("123");
     });
 
-    it("should format small generic binary values as compact hex", () => {
-      const b64 = btoa("test");
-      const wire = `BLOB:4:application/octet-stream:${b64}`;
+    it("should display printable UTF-8 BLOBs as text", () => {
+      const path = "/Users/test/Music/cafè.mp3";
+      const bytes = new TextEncoder().encode(path);
+      const b64 = btoa(String.fromCharCode(...bytes));
+      const wire = `BLOB:${bytes.length}:application/octet-stream:${b64}`;
 
-      expect(formatBlobValue(wire, "BLOB")).toBe("0x74657374");
-      expect(formatBlobValue(wire, "TINYBLOB")).toBe("0x74657374");
-      expect(formatBlobValue(wire, "MEDIUMBLOB")).toBe("0x74657374");
-      expect(formatBlobValue(wire, "LONGBLOB")).toBe("0x74657374");
+      expect(formatBlobValue(wire, "BLOB")).toBe(path);
+      expect(formatBlobValue(wire, "TINYBLOB")).toBe(path);
+      expect(formatBlobValue(wire, "MEDIUMBLOB")).toBe(path);
+      expect(formatBlobValue(wire, "LONGBLOB")).toBe(path);
+    });
+
+    it("should format invalid UTF-8 BLOBs as compact hex", () => {
+      const bytes = [0xff, 0xfe, 0xfd];
+      const b64 = btoa(String.fromCharCode(...bytes));
+      const wire = `BLOB:3:application/octet-stream:${b64}`;
+
+      expect(formatBlobValue(wire, "BLOB")).toBe("0xfffefd");
+    });
+
+    it("should keep UTF-8 BLOBs with binary control bytes in hex", () => {
+      const b64 = btoa("text\0value");
+      const wire = `BLOB:10:application/octet-stream:${b64}`;
+
+      expect(formatBlobValue(wire, "BLOB")).toBe("0x746578740076616c7565");
     });
 
     it("should show all 16 bytes of a binary identifier", () => {


### PR DESCRIPTION
## Summary

- display complete generic BLOB values as text when they contain printable UTF-8
- keep hexadecimal previews for invalid UTF-8 and binary control characters
- add coverage for Unicode file paths and binary fallback behavior

## Testing

- `pnpm test tests/utils/blob.test.ts tests/utils/dataGrid.test.ts tests/utils/clipboard.test.ts`
- `pnpm exec eslint src/utils/blob.ts`
- `pnpm exec tsc --noEmit`

Fixes #695
