### PR TITLE
fix(ui): stable keys, useCopyFeedback hook, sanitize HTML, eliminate render-time setState

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6459,7 +6459,7 @@ dependencies = [
 
 [[package]]
 name = "tabularis"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src/components/ConnectionIconImage.tsx
+++ b/src/components/ConnectionIconImage.tsx
@@ -8,21 +8,21 @@ interface Props {
   fallback: React.ReactNode;
 }
 
-export function ConnectionIconImage({ path, size, fallback }: Props) {
-  // Reset src/failed when path changes by keying state to the current path.
-  // This avoids calling setState inside an effect body (react-hooks/set-state-in-effect).
-  const [loadedPath, setLoadedPath] = useState<string>(path);
+/**
+ * Outer wrapper that keys on `path` so React unmounts/remounts the inner
+ * component whenever the path changes — cleanly resetting all internal
+ * state without calling setState during render or inside an effect body.
+ */
+export function ConnectionIconImage(props: Props) {
+  return <ConnectionIconImageInner key={props.path} {...props} />;
+}
+
+function ConnectionIconImageInner({ path, size, fallback }: Props) {
   const [src, setSrc] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
   const mountedRef = useRef(true);
 
   useEffect(() => () => { mountedRef.current = false; }, []);
-
-  if (loadedPath !== path) {
-    setLoadedPath(path);
-    setSrc(null);
-    setFailed(false);
-  }
 
   useEffect(() => {
     let cancelled = false;

--- a/src/components/layout/ExplorerSidebar.tsx
+++ b/src/components/layout/ExplorerSidebar.tsx
@@ -78,6 +78,7 @@ import { QueryHistorySection } from "./sidebar/QueryHistorySection";
 import { NotebooksSection } from "./sidebar/NotebooksSection";
 import { renameNotebook, deleteNotebook, listNotebooks, NOTEBOOKS_CHANGED_EVENT } from "../../utils/notebookStore";
 import { useConnectionLayoutContext } from "../../hooks/useConnectionLayoutContext";
+import { useCopyFeedback } from "../../hooks/useCopyFeedback";
 import { useDrivers } from "../../hooks/useDrivers";
 import { useDatabaseObjectNavigation } from "../../hooks/useDatabaseObjectNavigation";
 import { getConnectionAccent } from "../../utils/driverUI";
@@ -200,7 +201,7 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
   const [schemaVersion, setSchemaVersion] = useState(0);
   const sidebarBodyRef = useRef<HTMLDivElement>(null);
   const [schemaErrorExpanded, setSchemaErrorExpanded] = useState(false);
-  const [schemaErrorCopied, setSchemaErrorCopied] = useState(false);
+  const { copied: schemaErrorCopied, copy: copySchemaError } = useCopyFeedback(1500);
 
   const { splitView, isSplitVisible, explorerConnectionId, setExplorerConnectionId } = useConnectionLayoutContext();
 
@@ -907,11 +908,7 @@ export const ExplorerSidebar = ({ sidebarWidth, startResize, onCollapse, sidebar
                         {schemaLoadError}
                       </pre>
                       <button
-                        onClick={() => {
-                          navigator.clipboard.writeText(schemaLoadError);
-                          setSchemaErrorCopied(true);
-                          setTimeout(() => setSchemaErrorCopied(false), 1500);
-                        }}
+                        onClick={() => copySchemaError(schemaLoadError)}
                         title={t("sidebar.copyError")}
                         className="absolute top-1.5 right-1.5 p-1 rounded hover:bg-surface-tertiary text-muted hover:text-secondary transition-colors"
                       >

--- a/src/components/modals/AlertModal.tsx
+++ b/src/components/modals/AlertModal.tsx
@@ -1,8 +1,7 @@
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertTriangle, Info, AlertCircle, X, Copy, Check } from "lucide-react";
 import { Modal } from "../ui/Modal";
-import { copyTextToClipboard } from "../../utils/clipboard";
+import { useCopyFeedback } from "../../hooks/useCopyFeedback";
 import type { AlertKind } from "../../contexts/AlertContext";
 
 interface AlertModalProps {
@@ -22,18 +21,14 @@ const iconConfig: Record<AlertKind, { Icon: typeof Info; bgClass: string; textCl
 export const AlertModal = ({ isOpen, onClose, title, message, kind }: AlertModalProps) => {
   const { t } = useTranslation();
   const { Icon, bgClass, textClass } = iconConfig[kind];
-  const [copied, setCopied] = useState(false);
+  const { copied, copy, reset } = useCopyFeedback(1500);
 
   const handleClose = () => {
-    setCopied(false);
+    reset();
     onClose();
   };
 
-  const handleCopy = async () => {
-    await copyTextToClipboard(message);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-  };
+  const handleCopy = () => copy(message);
 
   return (
     <Modal isOpen={isOpen} onClose={handleClose}>

--- a/src/components/modals/ExportProgressModal.tsx
+++ b/src/components/modals/ExportProgressModal.tsx
@@ -103,7 +103,7 @@ export const ExportProgressModal = ({
               onClick={onClose}
               className="px-4 py-2 bg-surface-tertiary hover:bg-surface-tertiary text-white rounded flex items-center gap-2 transition-colors text-sm font-medium"
             >
-              {t("common.close")} {/* Assicurati che "close" esista in common, altrimenti usa "cancel" o aggiungilo */}
+              {t("common.close")}
             </button>
           )}
         </div>

--- a/src/components/modals/ExportProgressModal.tsx
+++ b/src/components/modals/ExportProgressModal.tsx
@@ -103,7 +103,7 @@ export const ExportProgressModal = ({
               onClick={onClose}
               className="px-4 py-2 bg-surface-tertiary hover:bg-surface-tertiary text-white rounded flex items-center gap-2 transition-colors text-sm font-medium"
             >
-              {t("common.close")}
+              {t("common.close")} {/* Ensure "close" exists in common; if not, use "cancel" or add it */}
             </button>
           )}
         </div>

--- a/src/components/modals/GenerateSQLModal.tsx
+++ b/src/components/modals/GenerateSQLModal.tsx
@@ -5,6 +5,7 @@ import {X, Loader2, Copy, Check, FileCode, List, Table2, PenLine, Trash2, Play} 
 import { invoke } from "@tauri-apps/api/core";
 import { useNavigate } from "react-router-dom";
 import { useDatabase } from "../../hooks/useDatabase";
+import { useCopyFeedback } from "../../hooks/useCopyFeedback";
 import { Modal } from "../ui/Modal";
 import { SqlPreview } from "../ui/SqlPreview";
 import { useAlert } from "../../hooks/useAlert";
@@ -53,7 +54,7 @@ export const GenerateSQLModal = ({
   const [sql, setSql] = useState<string>("");
   const [columns, setColumns] = useState<TableColumn[]>([]);
   const [loading, setLoading] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const { copied, copy: copyText } = useCopyFeedback();
 
   useEffect(() => {
     if (!isOpen || !connectionId || !tableName) return;
@@ -158,11 +159,7 @@ export const GenerateSQLModal = ({
     onClose();
   };
 
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(displayedSql);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
+  const handleCopy = () => copyText(displayedSql);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>

--- a/src/components/modals/McpModal.tsx
+++ b/src/components/modals/McpModal.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useTranslation } from "react-i18next";
 import { X, Check, Copy, Cpu, Terminal } from "lucide-react";
 import { useAlert } from "../../hooks/useAlert";
+import { useCopyFeedback } from "../../hooks/useCopyFeedback";
 import Editor from "@monaco-editor/react";
 import { useEditorTheme } from "../../hooks/useEditorTheme";
 import { loadMonacoTheme } from "../../themes/themeUtils";
@@ -61,8 +62,8 @@ export const McpModal = ({ isOpen, onClose }: McpModalProps) => {
   const { showAlert } = useAlert();
   const [clients, setClients] = useState<McpClientStatus[]>([]);
   const [loading, setLoading] = useState(true);
-  const [copiedJson, setCopiedJson] = useState(false);
-  const [copiedCmd, setCopiedCmd] = useState(false);
+  const { copied: copiedJson, copy: copyJson } = useCopyFeedback();
+  const { copied: copiedCmd, copy: copyCmd } = useCopyFeedback();
   const [selectedClient, setSelectedClient] = useState<McpClientStatus | null>(null);
 
   const jsonValue = useMemo(
@@ -226,11 +227,7 @@ export const McpModal = ({ isOpen, onClose }: McpModalProps) => {
                         {cliCommand}
                       </div>
                       <button
-                        onClick={() => {
-                          navigator.clipboard.writeText(cliCommand);
-                          setCopiedCmd(true);
-                          setTimeout(() => setCopiedCmd(false), 2000);
-                        }}
+                        onClick={() => copyCmd(cliCommand)}
                         className="absolute top-2 right-2 p-1.5 bg-surface-secondary text-secondary hover:text-primary rounded opacity-0 group-hover:opacity-100 transition-all"
                       >
                         {copiedCmd ? (
@@ -265,11 +262,7 @@ export const McpModal = ({ isOpen, onClose }: McpModalProps) => {
                         />
                       </div>
                       <button
-                        onClick={() => {
-                          navigator.clipboard.writeText(jsonValue);
-                          setCopiedJson(true);
-                          setTimeout(() => setCopiedJson(false), 2000);
-                        }}
+                        onClick={() => copyJson(jsonValue)}
                         className="absolute top-2 right-2 p-2 bg-surface-secondary text-secondary hover:text-primary rounded opacity-0 group-hover:opacity-100 transition-all z-10"
                       >
                         {copiedJson ? (

--- a/src/components/modals/PluginInstallErrorModal.tsx
+++ b/src/components/modals/PluginInstallErrorModal.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Modal } from "../ui/Modal";
 import { X, AlertTriangle, Copy, Check, FolderOpen, RefreshCw, Loader2 } from "lucide-react";
+import { useCopyFeedback } from "../../hooks/useCopyFeedback";
 
 interface PluginInstallErrorModalProps {
   isOpen: boolean;
@@ -25,14 +26,10 @@ export const PluginInstallErrorModal = ({
   onReload,
 }: PluginInstallErrorModalProps) => {
   const { t } = useTranslation();
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyFeedback();
   const [reloading, setReloading] = useState(false);
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(error);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
+  const handleCopy = () => copy(error);
 
   const handleReload = async () => {
     if (!onReload) return;

--- a/src/components/modals/PluginStartErrorModal.tsx
+++ b/src/components/modals/PluginStartErrorModal.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertTriangle, X, Copy, Check, Settings } from "lucide-react";
 import { Modal } from "../ui/Modal";
+import { useCopyFeedback } from "../../hooks/useCopyFeedback";
 
 interface PluginStartErrorModalProps {
   isOpen: boolean;
@@ -19,13 +19,9 @@ export const PluginStartErrorModal = ({
   onConfigureInterpreter,
 }: PluginStartErrorModalProps) => {
   const { t } = useTranslation();
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyFeedback();
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(error);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
+  const handleCopy = () => copy(error);
 
   const handleConfigure = () => {
     onClose();

--- a/src/components/modals/connection/ConnectionDiagnosticsModal.tsx
+++ b/src/components/modals/connection/ConnectionDiagnosticsModal.tsx
@@ -61,17 +61,12 @@ export const ConnectionDiagnosticsModal = ({
   );
 
   const copyReport = async () => {
-    const report = formatDiagnosticsReport({
+    await copy(formatDiagnosticsReport({
       summary: title,
       recovery: error?.recoveryKey ? t(error.recoveryKey) : null,
       logLines,
       detail: error?.detail || null,
-    });
-    try {
-      await copy(report);
-    } catch (err) {
-      console.error("Failed to copy diagnostics:", err);
-    }
+    }));
   };
 
   return (

--- a/src/components/modals/connection/ConnectionDiagnosticsModal.tsx
+++ b/src/components/modals/connection/ConnectionDiagnosticsModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCopyFeedback } from "../../../hooks/useCopyFeedback";
 import { useTranslation } from "react-i18next";
 import {
   AlertCircle,
@@ -48,7 +48,7 @@ export const ConnectionDiagnosticsModal = ({
   log,
 }: ConnectionDiagnosticsModalProps) => {
   const { t } = useTranslation();
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyFeedback();
 
   if (!isOpen) return null;
 
@@ -68,9 +68,7 @@ export const ConnectionDiagnosticsModal = ({
       detail: error?.detail || null,
     });
     try {
-      await navigator.clipboard.writeText(report);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      await copy(report);
     } catch (err) {
       console.error("Failed to copy diagnostics:", err);
     }

--- a/src/components/notebook/NotebookHistoryPanel.tsx
+++ b/src/components/notebook/NotebookHistoryPanel.tsx
@@ -74,7 +74,7 @@ export function NotebookHistoryPanel({
             const descriptor = descriptorAt(index);
             return (
               <button
-                key={`history-${index}`}
+                key={index}
                 onClick={() => {
                   if (!isCurrent) onJump(index);
                 }}

--- a/src/components/notebook/NotebookHistoryPanel.tsx
+++ b/src/components/notebook/NotebookHistoryPanel.tsx
@@ -74,7 +74,7 @@ export function NotebookHistoryPanel({
             const descriptor = descriptorAt(index);
             return (
               <button
-                key={index}
+                key={`history-${index}`}
                 onClick={() => {
                   if (!isCurrent) onJump(index);
                 }}

--- a/src/components/notebook/NotebookOutline.tsx
+++ b/src/components/notebook/NotebookOutline.tsx
@@ -57,7 +57,10 @@ function OutlineAiButton({
       tabIndex={0}
       onClick={handleClick}
       onKeyDown={(e) => {
-        if (e.key === "Enter") handleClick(e as unknown as React.MouseEvent);
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleClick(e as unknown as React.MouseEvent);
+        }
       }}
       className="p-0.5 text-muted hover:text-purple-300 transition-colors rounded"
       title={t("editor.notebook.aiGenerateOutlineNames")}

--- a/src/components/notebook/NotebookView.tsx
+++ b/src/components/notebook/NotebookView.tsx
@@ -303,7 +303,7 @@ export function NotebookView({
       flushSync(() => updateNotebook(newCells));
       cellRefsMap.current
         .get(newCellId)
-        ?.scrollIntoView({ behavior: "smooth", block: "center" });
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
       focusCell(newCellId);
       return newCellId;
     },
@@ -707,7 +707,7 @@ export function NotebookView({
 
   const scrollToCell = useCallback((cellId: string) => {
     const el = cellRefsMap.current.get(cellId);
-    el?.scrollIntoView({ behavior: "smooth", block: "center" });
+    el?.scrollIntoView({ behavior: "smooth", block: "start" });
   }, []);
 
   // Keyboard shortcuts (only for the active notebook tab):
@@ -888,7 +888,7 @@ export function NotebookView({
             }}
             onDragOver={handleDragOver(index)}
             onDrop={handleDrop(index)}
-            className="relative"
+            className="relative scroll-mt-4"
           >
             {showLineAt(index) && renderDropLine("top")}
             <NotebookCellWrapper

--- a/src/components/ui/ContextMenu.tsx
+++ b/src/components/ui/ContextMenu.tsx
@@ -167,9 +167,10 @@ const SubmenuRow = ({
             ${openLeft ? 'right-full mr-1 origin-top-right' : 'left-full ml-1 origin-top-left'}
           `}
         >
-          {item.submenu.map((sub, i) => (
-            <MenuRow key={i} item={sub} onClose={onClose} />
-          ))}
+          {item.submenu.map((sub, i) => {
+            const subKey = sub.separator ? `sub-sep-${i}` : (sub.label ?? `sub-${i}`);
+            return <MenuRow key={subKey} item={sub} onClose={onClose} />;
+          })}
         </div>
       )}
     </div>
@@ -245,13 +246,14 @@ export const ContextMenu = ({ x, y, items, onClose, children, boundaryRight }: C
       style={style}
       className="fixed z-50 min-w-[160px] bg-surface-secondary border border-strong rounded-lg shadow-xl py-1 animate-in fade-in zoom-in-95 duration-100"
     >
-      {items.map((item, index) =>
-        item.submenu ? (
-          <SubmenuRow key={index} item={item} onClose={onClose} openLeft={openSubmenuLeft} />
+      {items.map((item, index) => {
+        const key = item.separator ? `sep-${index}` : (item.label ?? `item-${index}`);
+        return item.submenu ? (
+          <SubmenuRow key={key} item={item} onClose={onClose} openLeft={openSubmenuLeft} />
         ) : (
-          <MenuRow key={index} item={item} onClose={onClose} />
-        ),
-      )}
+          <MenuRow key={key} item={item} onClose={onClose} />
+        );
+      })}
       {children}
     </div>
   );

--- a/src/components/ui/ContextMenu.tsx
+++ b/src/components/ui/ContextMenu.tsx
@@ -168,7 +168,7 @@ const SubmenuRow = ({
           `}
         >
           {item.submenu.map((sub, i) => {
-            const subKey = sub.separator ? `sub-sep-${i}` : (sub.label ?? `sub-${i}`);
+            const subKey = sub.separator ? `sub-sep-${i}` : (sub.label ? `${sub.label}-${i}` : `sub-${i}`);
             return <MenuRow key={subKey} item={sub} onClose={onClose} />;
           })}
         </div>
@@ -247,7 +247,7 @@ export const ContextMenu = ({ x, y, items, onClose, children, boundaryRight }: C
       className="fixed z-50 min-w-[160px] bg-surface-secondary border border-strong rounded-lg shadow-xl py-1 animate-in fade-in zoom-in-95 duration-100"
     >
       {items.map((item, index) => {
-        const key = item.separator ? `sep-${index}` : (item.label ?? `item-${index}`);
+        const key = item.separator ? `sep-${index}` : (item.label ? `${item.label}-${index}` : `item-${index}`);
         return item.submenu ? (
           <SubmenuRow key={key} item={item} onClose={onClose} openLeft={openSubmenuLeft} />
         ) : (

--- a/src/components/ui/ErrorDisplay.tsx
+++ b/src/components/ui/ErrorDisplay.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Check, ChevronDown, ChevronUp, Copy } from "lucide-react";
 import type { TFunction } from "i18next";
+import { useCopyFeedback } from "../../hooks/useCopyFeedback";
 
 interface ErrorDisplayProps {
   error: string;
@@ -9,18 +10,14 @@ interface ErrorDisplayProps {
 
 export function ErrorDisplay({ error, t }: ErrorDisplayProps) {
   const [showDetails, setShowDetails] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyFeedback(1500);
 
   const separatorIndex = error.indexOf("\n\n");
   const hasDetails = separatorIndex !== -1 && separatorIndex < error.length - 2;
   const brief = hasDetails ? error.slice(0, separatorIndex) : error;
   const details = hasDetails ? error.slice(separatorIndex + 2) : "";
 
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(error);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1500);
-  };
+  const handleCopy = () => copy(error);
 
   return (
     <div className="p-4 text-red-400 font-mono text-sm bg-red-900/10 h-full overflow-auto select-text">

--- a/src/components/ui/FilterRow.tsx
+++ b/src/components/ui/FilterRow.tsx
@@ -36,9 +36,8 @@ export const FilterRow = ({
   const operators = getOperatorsForType(selectedCol?.data_type ?? "");
   const enabled = filter.enabled !== false;
 
-  const noValueOps = NO_VALUE_OPS;
   const isBetween = filter.operator === "BETWEEN";
-  const noValue = noValueOps.includes(filter.operator);
+  const noValue = NO_VALUE_OPS.includes(filter.operator);
 
   const handleColumnChange = (col: string) => {
     const colMeta = columns.find((c) => c.name === col);

--- a/src/components/ui/FilterRow.tsx
+++ b/src/components/ui/FilterRow.tsx
@@ -6,6 +6,8 @@ import { getOperatorsForType } from "../../utils/filterBar";
 import type { StructuredFilter, FilterOperator } from "../../utils/filterBar";
 import { StyledSelect } from "./StyledSelect";
 
+const NO_VALUE_OPS: FilterOperator[] = ["IS NULL", "IS NOT NULL"];
+
 export interface FilterRowProps {
   filter: StructuredFilter;
   columns: TableColumn[];
@@ -34,7 +36,7 @@ export const FilterRow = ({
   const operators = getOperatorsForType(selectedCol?.data_type ?? "");
   const enabled = filter.enabled !== false;
 
-  const noValueOps: FilterOperator[] = ["IS NULL", "IS NOT NULL"];
+  const noValueOps = NO_VALUE_OPS;
   const isBetween = filter.operator === "BETWEEN";
   const noValue = noValueOps.includes(filter.operator);
 

--- a/src/components/ui/GeometryInput.tsx
+++ b/src/components/ui/GeometryInput.tsx
@@ -117,8 +117,6 @@ export const GeometryInput = ({
       : t("geometryInput.wktPlaceholder");
   };
 
-
-
   if (!isGeometricType(dataType)) {
     // Fallback to regular input for non-geometric types
     return (

--- a/src/components/ui/GeometryInput.tsx
+++ b/src/components/ui/GeometryInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useMemo } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Calculator, ChevronDown } from "lucide-react";
 import { isGeometricType } from "../../utils/geometry";
@@ -109,13 +109,13 @@ export const GeometryInput = ({
       : t("geometryInput.wktPlaceholder");
   };
 
-  const sqlFunctions = useMemo(() => [
+  const sqlFunctions = [
     { label: "ST_GeomFromText", template: "ST_GeomFromText('POINT(0 0)', 4326)" },
     { label: "ST_GeomFromText (no SRID)", template: "ST_GeomFromText('POINT(0 0)')" },
     { label: "ST_Point", template: "ST_Point(0, 0)" },
     { label: "ST_MakePoint", template: "ST_MakePoint(0, 0)" },
     { label: "ST_SetSRID", template: "ST_SetSRID(ST_MakePoint(0, 0), 4326)" },
-  ], []);
+  ];
 
   if (!isGeometricType(dataType)) {
     // Fallback to regular input for non-geometric types

--- a/src/components/ui/GeometryInput.tsx
+++ b/src/components/ui/GeometryInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Calculator, ChevronDown } from "lucide-react";
 import { isGeometricType } from "../../utils/geometry";
@@ -109,13 +109,13 @@ export const GeometryInput = ({
       : t("geometryInput.wktPlaceholder");
   };
 
-  const sqlFunctions = [
+  const sqlFunctions = useMemo(() => [
     { label: "ST_GeomFromText", template: "ST_GeomFromText('POINT(0 0)', 4326)" },
     { label: "ST_GeomFromText (no SRID)", template: "ST_GeomFromText('POINT(0 0)')" },
     { label: "ST_Point", template: "ST_Point(0, 0)" },
     { label: "ST_MakePoint", template: "ST_MakePoint(0, 0)" },
     { label: "ST_SetSRID", template: "ST_SetSRID(ST_MakePoint(0, 0), 4326)" },
-  ];
+  ], []);
 
   if (!isGeometricType(dataType)) {
     // Fallback to regular input for non-geometric types

--- a/src/components/ui/GeometryInput.tsx
+++ b/src/components/ui/GeometryInput.tsx
@@ -7,6 +7,14 @@ import {
   toggleGeometryMode,
 } from "../../utils/geometryInput";
 
+const SQL_FUNCTIONS = [
+  { label: "ST_GeomFromText", template: "ST_GeomFromText('POINT(0 0)', 4326)" },
+  { label: "ST_GeomFromText (no SRID)", template: "ST_GeomFromText('POINT(0 0)')" },
+  { label: "ST_Point", template: "ST_Point(0, 0)" },
+  { label: "ST_MakePoint", template: "ST_MakePoint(0, 0)" },
+  { label: "ST_SetSRID", template: "ST_SetSRID(ST_MakePoint(0, 0), 4326)" },
+];
+
 interface DropdownPosition {
   top: number;
   left: number;
@@ -109,13 +117,7 @@ export const GeometryInput = ({
       : t("geometryInput.wktPlaceholder");
   };
 
-  const sqlFunctions = [
-    { label: "ST_GeomFromText", template: "ST_GeomFromText('POINT(0 0)', 4326)" },
-    { label: "ST_GeomFromText (no SRID)", template: "ST_GeomFromText('POINT(0 0)')" },
-    { label: "ST_Point", template: "ST_Point(0, 0)" },
-    { label: "ST_MakePoint", template: "ST_MakePoint(0, 0)" },
-    { label: "ST_SetSRID", template: "ST_SetSRID(ST_MakePoint(0, 0), 4326)" },
-  ];
+
 
   if (!isGeometricType(dataType)) {
     // Fallback to regular input for non-geometric types
@@ -208,7 +210,7 @@ export const GeometryInput = ({
                 </p>
               </div>
                <div className="py-1">
-                {sqlFunctions.map((func) => (
+                {SQL_FUNCTIONS.map((func) => (
                   <button
                     key={func.label}
                     type="button"

--- a/src/components/ui/SqlHighlight.tsx
+++ b/src/components/ui/SqlHighlight.tsx
@@ -1,3 +1,4 @@
+import DOMPurify from "dompurify";
 import { useColorizedSql, formatSqlPreview } from "../../utils/sqlHighlight";
 
 interface SqlHighlightProps {
@@ -18,7 +19,7 @@ export function SqlHighlight({ sql, maxLines = 3 }: SqlHighlightProps) {
           WebkitLineClamp: maxLines,
           WebkitBoxOrient: "vertical",
         }}
-        dangerouslySetInnerHTML={{ __html: html }}
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }}
       />
     );
   }

--- a/src/hooks/useCopyFeedback.ts
+++ b/src/hooks/useCopyFeedback.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Encapsulates the common "copy text → show checkmark → reset" pattern
+ * used across dozens of components. Handles cleanup on unmount so
+ * `setState` is never called on an unmounted component.
+ *
+ * @param resetMs  Time in ms before `copied` resets to false (default 2000).
+ * @returns `{ copied, copy }` — `copy(text)` writes `text` to the
+ *          clipboard and flips `copied` to true for `resetMs` ms.
+ */
+export function useCopyFeedback(resetMs = 2000) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // Cleanup on unmount — prevents setState after unmount.
+  useEffect(() => clearTimer, [clearTimer]);
+
+  const copy = useCallback(
+    async (text: string) => {
+      await navigator.clipboard.writeText(text);
+      clearTimer();
+      setCopied(true);
+      timerRef.current = setTimeout(() => setCopied(false), resetMs);
+    },
+    [clearTimer, resetMs],
+  );
+
+  const reset = useCallback(() => {
+    clearTimer();
+    setCopied(false);
+  }, [clearTimer]);
+
+  return { copied, copy, reset } as const;
+}

--- a/src/hooks/useCopyFeedback.ts
+++ b/src/hooks/useCopyFeedback.ts
@@ -21,20 +21,21 @@ export function useCopyFeedback(resetMs = 2000) {
     }
   }, []);
 
-  // Cleanup on unmount — prevents setState after unmount.
+  // Cleanup on unmount — cancels any pending reset timer.
   useEffect(() => clearTimer, [clearTimer]);
 
   const copy = useCallback(
     async (text: string) => {
       try {
         await navigator.clipboard.writeText(text);
+        clearTimer();
+        setCopied(true);
+        timerRef.current = setTimeout(() => setCopied(false), resetMs);
       } catch (err) {
         console.error("Failed to copy to clipboard:", err);
-        return;
+        clearTimer();
+        setCopied(false);
       }
-      clearTimer();
-      setCopied(true);
-      timerRef.current = setTimeout(() => setCopied(false), resetMs);
     },
     [clearTimer, resetMs],
   );

--- a/src/hooks/useCopyFeedback.ts
+++ b/src/hooks/useCopyFeedback.ts
@@ -6,8 +6,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
  * `setState` is never called on an unmounted component.
  *
  * @param resetMs  Time in ms before `copied` resets to false (default 2000).
- * @returns `{ copied, copy }` — `copy(text)` writes `text` to the
+ * @returns `{ copied, copy, reset }` — `copy(text)` writes `text` to the
  *          clipboard and flips `copied` to true for `resetMs` ms.
+ *          `reset()` cancels the timer and immediately sets `copied` back to false.
  */
 export function useCopyFeedback(resetMs = 2000) {
   const [copied, setCopied] = useState(false);
@@ -25,7 +26,12 @@ export function useCopyFeedback(resetMs = 2000) {
 
   const copy = useCallback(
     async (text: string) => {
-      await navigator.clipboard.writeText(text);
+      try {
+        await navigator.clipboard.writeText(text);
+      } catch (err) {
+        console.error("Failed to copy to clipboard:", err);
+        return;
+      }
       clearTimer();
       setCopied(true);
       timerRef.current = setTimeout(() => setCopied(false), resetMs);

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -3864,7 +3864,7 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
                         const label = statementLabel(q);
                         return (
                         <div
-                          key={`query-${i}-${label}`}
+                          key={i}
                           className="flex items-center border-b border-strong/50 last:border-0 hover:bg-surface-tertiary/50 transition-colors group"
                         >
                           <button

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -3864,7 +3864,7 @@ export const Editor = ({ commandScopeId }: EditorProps) => {
                         const label = statementLabel(q);
                         return (
                         <div
-                          key={i}
+                          key={`query-${i}-${label}`}
                           className="flex items-center border-b border-strong/50 last:border-0 hover:bg-surface-tertiary/50 transition-colors group"
                         >
                           <button

--- a/src/pages/McpPage.tsx
+++ b/src/pages/McpPage.tsx
@@ -21,6 +21,7 @@ import {
 import { AiActivityPanel } from "../components/settings/AiActivityPanel";
 import { McpSafetySection } from "../components/modals/mcp/McpSafetySection";
 import { useAlert } from "../hooks/useAlert";
+import { useCopyFeedback } from "../hooks/useCopyFeedback";
 import { useEditorTheme } from "../hooks/useEditorTheme";
 import { loadMonacoTheme } from "../themes/themeUtils";
 
@@ -130,8 +131,8 @@ function McpSetupPanel() {
   const { showAlert } = useAlert();
   const [clients, setClients] = useState<McpClientStatus[]>([]);
   const [loading, setLoading] = useState(true);
-  const [copiedJson, setCopiedJson] = useState(false);
-  const [copiedCmd, setCopiedCmd] = useState(false);
+  const { copied: copiedJson, copy: copyJson } = useCopyFeedback();
+  const { copied: copiedCmd, copy: copyCmd } = useCopyFeedback();
   const [selectedClientId, setSelectedClientId] = useState<string | null>(null);
 
   const selectedClient = useMemo(
@@ -279,11 +280,7 @@ function McpSetupPanel() {
                   {cliCommand}
                 </div>
                 <button
-                  onClick={() => {
-                    navigator.clipboard.writeText(cliCommand);
-                    setCopiedCmd(true);
-                    setTimeout(() => setCopiedCmd(false), 2000);
-                  }}
+                  onClick={() => copyCmd(cliCommand)}
                   className="absolute right-2 top-2 rounded bg-surface-secondary p-1.5 text-secondary opacity-0 transition-all hover:text-primary group-hover:opacity-100"
                 >
                   {copiedCmd ? (
@@ -315,11 +312,7 @@ function McpSetupPanel() {
                   }}
                 />
                 <button
-                  onClick={() => {
-                    navigator.clipboard.writeText(jsonValue);
-                    setCopiedJson(true);
-                    setTimeout(() => setCopiedJson(false), 2000);
-                  }}
+                  onClick={() => copyJson(jsonValue)}
                   className="absolute right-2 top-2 z-10 rounded bg-surface-secondary p-2 text-secondary opacity-0 transition-all hover:text-primary group-hover:opacity-100"
                 >
                   {copiedJson ? (

--- a/tests/hooks/useCopyFeedback.test.ts
+++ b/tests/hooks/useCopyFeedback.test.ts
@@ -1,0 +1,115 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCopyFeedback } from "../../src/hooks/useCopyFeedback";
+
+const mockWriteText = vi.fn();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: mockWriteText },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("useCopyFeedback", () => {
+  it("starts with copied = false", () => {
+    const { result } = renderHook(() => useCopyFeedback());
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("sets copied to true immediately after a successful copy", async () => {
+    mockWriteText.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useCopyFeedback());
+
+    await act(async () => {
+      await result.current.copy("hello");
+    });
+
+    expect(result.current.copied).toBe(true);
+  });
+
+  it("resets copied to false after resetMs", async () => {
+    mockWriteText.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useCopyFeedback(1000));
+
+    await act(async () => {
+      await result.current.copy("hello");
+    });
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("restarts the timer on rapid successive copies", async () => {
+    mockWriteText.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useCopyFeedback(1000));
+
+    await act(async () => {
+      await result.current.copy("first");
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+
+    await act(async () => {
+      await result.current.copy("second");
+    });
+
+    // 600 ms after the second copy — timer should not have fired yet
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(result.current.copied).toBe(true);
+
+    // Full 1000 ms after the second copy — now it resets
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("does not set copied and logs an error when the clipboard rejects", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockWriteText.mockRejectedValue(new Error("permission denied"));
+    const { result } = renderHook(() => useCopyFeedback());
+
+    await act(async () => {
+      await result.current.copy("hello");
+    });
+
+    expect(result.current.copied).toBe(false);
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to copy to clipboard:",
+      expect.any(Error),
+    );
+    consoleError.mockRestore();
+  });
+
+  it("clears the timer on unmount so setState is never called after unmount", async () => {
+    mockWriteText.mockResolvedValue(undefined);
+    const { result, unmount } = renderHook(() => useCopyFeedback(1000));
+
+    await act(async () => {
+      await result.current.copy("hello");
+    });
+
+    unmount();
+
+    // Advancing time after unmount must not throw a setState-on-unmounted warning
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION

## Summary

Comprehensive React UI audit fixing anti-patterns across the codebase -- memory leaks, render-time `setState`, missing sanitization, unstable keys, unnecessary re-renders, and a scroll UX issue in the notebook.

## Changes

### 1) New: `useCopyFeedback` hook (`src/hooks/useCopyFeedback.ts`)

Replaced 11 instances of duplicated copy-to-clipboard + `setTimeout` pattern with a shared hook. The old pattern had no cleanup on unmount, causing `setState` calls on unmounted components.

**Affected files:** `AlertModal`, `McpModal`, `McpPage`, `GenerateSQLModal`, `PluginStartErrorModal`, `PluginInstallErrorModal`, `ConnectionDiagnosticsModal`, `ErrorDisplay`, `ExplorerSidebar`

```tsx
// Before (duplicated 11×, no cleanup)
const [copied, setCopied] = useState(false);
setTimeout(() => setCopied(false), 2000); // leaks on unmount

// After
const { copied, copy } = useCopyFeedback();
```

### 2) Stable keys in `ContextMenu.tsx`

Index-based keys caused stale hover/focus state when dynamic context menus were rebuilt with different items.

```tsx
// Before
key={index}

// After
key={item.label ? `${item.label}-${index}` : `sep-${index}`}
```

### 3) `dangerouslySetInnerHTML` sanitization in `SqlHighlight.tsx`

Added `DOMPurify.sanitize()` consistent with the existing pattern in `PluginReadmeModal.tsx`.

### 4) Eliminate render-time `setState` in `ConnectionIconImage.tsx`

Replaced a manual `loadedPath` tracking pattern (setState during render) with a keyed outer/inner component — React resets state naturally when `path` changes.

### 5) Prevent unnecessary re-renders

- **`FilterRow.tsx`** — `noValueOps` moved to module-level constant (was recreated every render)
- **`GeometryInput.tsx`** — sqlFunctions moved to module-level constant

### 6) Keyboard accessibility in `NotebookOutline.tsx`

`role="button"` elements must respond to both Enter **and** Space per WCAG. Added Space key handling.

### 7) Notebook scroll UX (`NotebookView.tsx`)

Cells now scroll to the **top** of the viewport (`block: "start"`) instead of the center. Added `scroll-mt-4` (16 px top margin) to each cell wrapper so the cell lands with breathing room rather than flush to the edge.

https://github.com/user-attachments/assets/ec18c714-9329-4c8f-9bdc-c7a4f08f9c0c



### 8) Comment hygiene (`ExportProgressModal.tsx`)

Translated a development-time comment from Italian to English per project rules.

## Testing
`pnpm typecheck` and `pnpm lint`
<img width="2414" height="908" alt="image" src="https://github.com/user-attachments/assets/410f123a-1991-4782-a80c-aa4cc7345f3c" />

`pnpm test -- --run`
<img width="2414" height="1724" alt="image" src="https://github.com/user-attachments/assets/eff2d50e-4131-4129-9ee1-f45a237e0fda" />
