### PR TITLE
fix(mysql): qualify SHOW CREATE routine with target schema

### DIFF
--- a/src-tauri/src/drivers/mysql/mod.rs
+++ b/src-tauri/src/drivers/mysql/mod.rs
@@ -1259,14 +1259,12 @@ pub async fn get_routine_definition(
     params: &ConnectionParams,
     routine_name: &str,
     routine_type: &str,
+    schema: Option<&str>,
 ) -> Result<String, String> {
+    let db_name = schema.unwrap_or_else(|| params.database.primary());
     let pool = get_mysql_pool(params).await?;
     let text = resolve_text_proto(&pool, params).await?;
-    let query = format!(
-        "SHOW CREATE {} `{}`",
-        routine_type,
-        escape_identifier(routine_name)
-    );
+    let query = routines::show_create_routine_sql(db_name, routine_name, routine_type);
 
     let row = fetch_one_row(&pool, text, &query, &[]).await?;
 
@@ -2113,9 +2111,9 @@ impl DatabaseDriver for MysqlDriver {
         params: &crate::models::ConnectionParams,
         routine_name: &str,
         routine_type: &str,
-        _schema: Option<&str>,
+        schema: Option<&str>,
     ) -> Result<String, String> {
-        get_routine_definition(params, routine_name, routine_type).await
+        get_routine_definition(params, routine_name, routine_type, schema).await
     }
 
     async fn get_db_privilege_catalog(
@@ -2233,9 +2231,9 @@ impl DatabaseDriver for MysqlDriver {
         params: &crate::models::ConnectionParams,
         routine_name: &str,
         routine_type: &str,
-        _schema: Option<&str>,
+        schema: Option<&str>,
     ) -> Result<String, String> {
-        let definition = get_routine_definition(params, routine_name, routine_type).await?;
+        let definition = get_routine_definition(params, routine_name, routine_type, schema).await?;
         Ok(routines::routine_edit_script(
             routine_name,
             routine_type,

--- a/src-tauri/src/drivers/mysql/routines.rs
+++ b/src-tauri/src/drivers/mysql/routines.rs
@@ -135,6 +135,22 @@ pub(super) fn drop_routine_sql(routine_name: &str, routine_type: &str) -> String
     format!("DROP {} {}", drop_keyword(routine_type), quoted(routine_name))
 }
 
+/// `SHOW CREATE PROCEDURE|FUNCTION` qualified with the target schema: the
+/// pool's session database is the connection default, so an unqualified
+/// lookup would raise error 1305 for routines in any other schema.
+pub(super) fn show_create_routine_sql(
+    schema: &str,
+    routine_name: &str,
+    routine_type: &str,
+) -> String {
+    format!(
+        "SHOW CREATE {} {}.{}",
+        drop_keyword(routine_type),
+        quoted(schema),
+        quoted(routine_name)
+    )
+}
+
 fn drop_keyword(routine_type: &str) -> &'static str {
     if routine_type.eq_ignore_ascii_case("FUNCTION") {
         "FUNCTION"

--- a/src-tauri/src/drivers/mysql/tests.rs
+++ b/src-tauri/src/drivers/mysql/tests.rs
@@ -488,6 +488,7 @@ mod multi_result_collector {
 mod routine_management {
     use super::super::routines::{
         drop_routine_sql, routine_call_sql, routine_create_template, routine_edit_script,
+        show_create_routine_sql,
     };
     use crate::models::RoutineCallArg;
 
@@ -595,6 +596,26 @@ mod routine_management {
         assert_eq!(
             drop_routine_sql("weird`name", "FUNCTION"),
             "DROP FUNCTION `weird``name`"
+        );
+    }
+
+    #[test]
+    fn show_create_qualifies_routine_with_schema() {
+        assert_eq!(
+            show_create_routine_sql("ppi", "laporanTertusukJarum", "PROCEDURE"),
+            "SHOW CREATE PROCEDURE `ppi`.`laporanTertusukJarum`"
+        );
+        assert_eq!(
+            show_create_routine_sql("aplikasi", "fn_add", "FUNCTION"),
+            "SHOW CREATE FUNCTION `aplikasi`.`fn_add`"
+        );
+    }
+
+    #[test]
+    fn show_create_escapes_schema_and_name() {
+        assert_eq!(
+            show_create_routine_sql("weird`db", "weird`name", "procedure"),
+            "SHOW CREATE PROCEDURE `weird``db`.`weird``name`"
         );
     }
 }


### PR DESCRIPTION
## What changed

Fixes #699.

Fetching a stored procedure or function definition on MySQL/MariaDB failed with error 1305 (`PROCEDURE <name> does not exist`) for every database other than the connection's default one. The driver issued `SHOW CREATE PROCEDURE \`name\`` without a schema prefix, so MySQL resolved the name against the session's default database regardless of which database the routine was opened from in the sidebar.

- `drivers/mysql/routines.rs`: new pure builder `show_create_routine_sql(schema, name, type)` that emits `SHOW CREATE PROCEDURE|FUNCTION \`schema\`.\`name\`` with proper backtick escaping. The keyword is normalized through the existing `drop_keyword` helper instead of interpolating the raw `routine_type` string into the statement.
- `drivers/mysql/mod.rs`: `get_routine_definition` now takes the `schema` parameter (falling back to the connection's primary database, same pattern as `get_routines`) and both the trait impl and `get_routine_edit_script` pass it through instead of dropping it.

Sidebar listing, parameters, drop and call script generation were already schema-aware; the definition/edit path was the only one resolving against the session default.

## Verification

- Unit tests added in `drivers/mysql/tests.rs` covering schema qualification for both routine types and backtick escaping of schema and routine names.
- `cargo test --lib drivers::mysql`: 64 passed.
- Manual repro from the issue: with a connection defaulting to one database, opening View Definition on a routine in another database now returns the full DDL instead of error 1305.