### PR TITLE
fix: rank tables first and tighten search in the quick navigator

### DIFF
--- a/src/components/modals/commandPalette/Palette.tsx
+++ b/src/components/modals/commandPalette/Palette.tsx
@@ -101,6 +101,9 @@ export const Palette = ({ labels, items, error }: PaletteProps) => {
       onClose={closePalette}
       onQueryChange={(nextQuery) => {
         setQuery(nextQuery);
+        // A new query means a new ranking, so the best match is the first
+        // row again rather than wherever the selection sat in the old list.
+        setSelectedIndex(0);
         setExecutionError(null);
       }}
       onSelectedIndexChange={setSelectedIndex}

--- a/src/components/modals/commandPalette/Palette.tsx
+++ b/src/components/modals/commandPalette/Palette.tsx
@@ -7,7 +7,10 @@ import type {
   PaletteItem,
 } from "../../../types/palette";
 import { toErrorMessage } from "../../../utils/errors";
-import { createPaletteSearch } from "../../../utils/paletteItems";
+import {
+  createPaletteSearch,
+  MAX_VISIBLE_PALETTE_RESULTS,
+} from "../../../utils/paletteItems";
 import { SpotlightPalette } from "../../ui/SpotlightPalette";
 import { PaletteResults } from "./PaletteResults";
 import { PALETTE_RESULTS_ID, paletteOptionId } from "./paletteIds";
@@ -60,7 +63,11 @@ export const Palette = ({ labels, items, error }: PaletteProps) => {
   );
 
   const search = useMemo(() => createPaletteSearch(items), [items]);
-  const results = useMemo(() => search(query), [search, query]);
+  const matches = useMemo(() => search(query), [search, query]);
+  const results = useMemo(
+    () => matches.slice(0, MAX_VISIBLE_PALETTE_RESULTS),
+    [matches],
+  );
   const activeIndex = Math.min(
     selectedIndex,
     Math.max(results.length - 1, 0),
@@ -108,7 +115,7 @@ export const Palette = ({ labels, items, error }: PaletteProps) => {
       }
       footer={
         <>
-          <span>{labels.getCountLabel?.(results.length)}</span>
+          <span>{labels.getCountLabel?.(matches.length)}</span>
           <div className="flex gap-4">
             <PaletteHint
               keys={["↑", "↓"]}

--- a/src/hooks/useCommandPaletteObjectItems.ts
+++ b/src/hooks/useCommandPaletteObjectItems.ts
@@ -101,7 +101,11 @@ export function useCommandPaletteObjectItems(
     if (!connectionId) return;
 
     if (hasSchemas) {
-      connectionData?.schemas.forEach((schema) => {
+      // Only the schemas selected in the explorer: a Postgres database with
+      // extensions installed carries thousands of functions in schemas the
+      // user has hidden, and loading them would also refill the list behind
+      // a search that had already ranked well.
+      connectionData?.selectedSchemas.forEach((schema) => {
         const schemaData = connectionData.schemaDataMap[schema];
         const requestKey = `schema:${connectionId}:${schema}`;
         if (schemaData?.isLoaded) {
@@ -145,7 +149,7 @@ export function useCommandPaletteObjectItems(
   }, [
     connectionData?.databaseDataMap,
     connectionData?.schemaDataMap,
-    connectionData?.schemas,
+    connectionData?.selectedSchemas,
     connectionId,
     hasSchemas,
     isMultiDatabase,
@@ -158,7 +162,7 @@ export function useCommandPaletteObjectItems(
         activeConnectionId: connectionId,
         hasSchemas,
         isMultiDb: isMultiDatabase,
-        schemas: connectionData?.schemas ?? [],
+        schemas: connectionData?.selectedSchemas ?? [],
         schemaDataMap: connectionData?.schemaDataMap ?? {},
         selectedDatabases,
         databaseDataMap: connectionData?.databaseDataMap ?? {},
@@ -173,7 +177,7 @@ export function useCommandPaletteObjectItems(
       connectionData?.databaseDataMap,
       connectionData?.routines,
       connectionData?.schemaDataMap,
-      connectionData?.schemas,
+      connectionData?.selectedSchemas,
       connectionData?.tables,
       connectionData?.triggers,
       connectionData?.views,

--- a/src/utils/objectPaletteItems.ts
+++ b/src/utils/objectPaletteItems.ts
@@ -65,7 +65,16 @@ export function createObjectPaletteItems({
   labels,
   runtime,
 }: CreateObjectPaletteItemsOptions): PaletteItem[] {
-  return navigatorItems.map((item) => {
+  const seen = new Set<string>();
+
+  return navigatorItems.flatMap((item) => {
+    // Overloaded routines come back once per signature under the same name,
+    // and the definition loader only takes the name, so the extra rows would
+    // open the same thing and collide as React keys.
+    const id = paletteItemId(item);
+    if (seen.has(id)) return [];
+    seen.add(id);
+
     const object = toDatabaseObject(item, {
       connectionId,
       driver,
@@ -74,7 +83,7 @@ export function createObjectPaletteItems({
     const { open, actions } = createActions(object, runtime, labels);
 
     return {
-      id: `${item.type}:${item.schema ?? ""}:${item.name}`,
+      id,
       title: item.name,
       description: item.detail,
       group: hasGroups ? item.schema : undefined,
@@ -86,6 +95,15 @@ export function createObjectPaletteItems({
       actions,
     };
   });
+}
+
+function paletteItemId(item: NavigatorItem): string {
+  const parts = [item.type, item.schema ?? "", item.name];
+  // A function and a procedure may share a name, and a trigger name is only
+  // unique per table.
+  if (item.type === "routine") parts.push(item.item.routine_type);
+  if (item.type === "trigger") parts.push(item.item.table_name);
+  return parts.join(":");
 }
 
 /**

--- a/src/utils/objectPaletteItems.ts
+++ b/src/utils/objectPaletteItems.ts
@@ -31,6 +31,21 @@ interface ObjectPaletteLabels {
   type: Record<NavigatorItem["type"], string>;
 }
 
+/**
+ * Added to the fuzzy match score (0–100) so that, for comparable matches,
+ * tables rank above views and both rank above routines and triggers. A
+ * PostgreSQL schema with PostGIS installed carries over a thousand functions,
+ * and people open the navigator to switch tables far more often than to open a
+ * function. The boost stays well below an exact-match score, so typing a
+ * routine's full name still puts that routine first.
+ */
+export const OBJECT_TYPE_RELEVANCE: Record<NavigatorItem["type"], number> = {
+  table: 20,
+  view: 10,
+  routine: 0,
+  trigger: 0,
+};
+
 interface CreateObjectPaletteItemsOptions {
   navigatorItems: NavigatorItem[];
   connectionId: string;
@@ -66,6 +81,7 @@ export function createObjectPaletteItems({
       badge: labels.type[item.type],
       keywords: item.schema ? [item.schema] : undefined,
       icon: item.type,
+      relevance: OBJECT_TYPE_RELEVANCE[item.type],
       primaryAction: open,
       actions,
     };

--- a/src/utils/paletteItems.ts
+++ b/src/utils/paletteItems.ts
@@ -9,6 +9,13 @@ import type { PaletteItem } from "../types/palette";
  */
 export const PINNED_PALETTE_RELEVANCE = 100;
 
+/**
+ * Rows rendered per query. The list is not virtualised, and painting every one
+ * of a large schema's objects on each keystroke is what makes typing lag; the
+ * footer still reports the full match count so nothing looks lost.
+ */
+export const MAX_VISIBLE_PALETTE_RESULTS = 100;
+
 function keepGroupsContiguous<T extends { item: PaletteItem }>(
   matches: T[],
 ): T[] {
@@ -55,7 +62,10 @@ export function createPaletteSearch(
         { name: "group", weight: 0.1 },
         { name: "badge", weight: 0.05 },
       ],
-      threshold: 0.4,
+      // 0.4 lets a five-letter query match anything within two edits, which
+      // against a thousand extension functions keeps most of them in the
+      // list. 0.3 still tolerates a typo per four characters.
+      threshold: 0.3,
       ignoreLocation: true,
       includeScore: true,
     }));

--- a/tests/components/modals/CommandPaletteModal.test.tsx
+++ b/tests/components/modals/CommandPaletteModal.test.tsx
@@ -17,6 +17,7 @@ import type {
   CommandPaletteStateContextType,
 } from "../../../src/contexts/CommandPaletteContext";
 import { CommandPaletteModal } from "../../../src/components/modals/CommandPaletteModal";
+import { MAX_VISIBLE_PALETTE_RESULTS } from "../../../src/utils/paletteItems";
 
 const navigateMock = vi.fn();
 const openEditorMock = vi.fn();
@@ -389,6 +390,39 @@ describe("CommandPaletteModal", () => {
       initialQuery: "SELECT 1",
       targetConnectionId: "connection-1",
     });
+  });
+
+  it("should list tables before routines when the query is empty", () => {
+    connectionData.routines = [
+      { name: "st_union", routine_type: "FUNCTION" },
+    ];
+    connectionData.tables = [{ name: "users" }];
+    renderPalette({ state: { activePalette: "objects" } });
+
+    expect(
+      screen.getAllByRole("option").map((option) =>
+        option.getAttribute("aria-label"),
+      ),
+    ).toEqual(["users", "st_union"]);
+  });
+
+  it("should cap the rendered rows while still counting every match", () => {
+    connectionData.routines = Array.from(
+      { length: MAX_VISIBLE_PALETTE_RESULTS + 50 },
+      (_, index) => ({
+        name: `fn_${index}`,
+        routine_type: "FUNCTION",
+      }),
+    );
+    renderPalette({ state: { activePalette: "objects" } });
+
+    expect(screen.getAllByRole("option")).toHaveLength(
+      MAX_VISIBLE_PALETTE_RESULTS,
+    );
+    expect(screen.getAllByRole("option")[0]).toHaveAttribute(
+      "aria-label",
+      "users",
+    );
   });
 
   it("should render database objects through the same palette", () => {

--- a/tests/components/modals/CommandPaletteModal.test.tsx
+++ b/tests/components/modals/CommandPaletteModal.test.tsx
@@ -38,6 +38,7 @@ const connectionData = {
     timing: string;
   }>,
   schemas: [] as string[],
+  selectedSchemas: [] as string[],
   schemaDataMap: {},
   databaseDataMap: {},
   activeSchema: "public",
@@ -176,6 +177,7 @@ describe("CommandPaletteModal", () => {
     connectionData.routines = [];
     connectionData.triggers = [];
     connectionData.schemas = [];
+    connectionData.selectedSchemas = [];
     connectionData.schemaDataMap = {};
   });
 
@@ -285,6 +287,7 @@ describe("CommandPaletteModal", () => {
     connectionData.capabilities = { schemas: true };
     connectionData.tables = [];
     connectionData.schemas = ["public"];
+    connectionData.selectedSchemas = ["public"];
     connectionData.schemaDataMap = {
       public: {
         tables: [{ name: "users" }],
@@ -404,6 +407,73 @@ describe("CommandPaletteModal", () => {
         option.getAttribute("aria-label"),
       ),
     ).toEqual(["users", "st_union"]);
+  });
+
+  it("should move the selection back to the first row when the query changes", () => {
+    connectionData.routines = [
+      { name: "st_union", routine_type: "FUNCTION" },
+      { name: "st_buffer", routine_type: "FUNCTION" },
+    ];
+    renderPalette({ state: { activePalette: "objects" } });
+    const input = screen.getByRole("combobox");
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(screen.getAllByRole("option")[2]).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    fireEvent.change(input, { target: { value: "st_" } });
+
+    expect(screen.getAllByRole("option")[0]).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("should list overloaded routines once", () => {
+    connectionData.tables = [];
+    connectionData.routines = [
+      { name: "approx_percentile", routine_type: "FUNCTION" },
+      { name: "approx_percentile", routine_type: "FUNCTION" },
+      { name: "approx_percentile", routine_type: "FUNCTION" },
+    ];
+    renderPalette({ state: { activePalette: "objects" } });
+
+    expect(screen.getAllByRole("option")).toHaveLength(1);
+  });
+
+  it("should only list objects from the schemas selected in the explorer", () => {
+    connectionData.capabilities = { schemas: true };
+    connectionData.tables = [];
+    connectionData.schemas = ["public", "topology"];
+    connectionData.selectedSchemas = ["public"];
+    connectionData.schemaDataMap = {
+      public: {
+        tables: [{ name: "users" }],
+        views: [],
+        routines: [],
+        triggers: [],
+        isLoading: false,
+        isLoaded: true,
+      },
+      topology: {
+        tables: [],
+        views: [],
+        routines: [{ name: "st_union", routine_type: "FUNCTION" }],
+        triggers: [],
+        isLoading: false,
+        isLoaded: true,
+      },
+    };
+    renderPalette({ state: { activePalette: "objects" } });
+
+    expect(
+      screen.getAllByRole("option").map((option) =>
+        option.getAttribute("aria-label"),
+      ),
+    ).toEqual(["users"]);
   });
 
   it("should cap the rendered rows while still counting every match", () => {

--- a/tests/hooks/useCommandPaletteObjectItems.test.tsx
+++ b/tests/hooks/useCommandPaletteObjectItems.test.tsx
@@ -62,6 +62,7 @@ describe("useCommandPaletteObjectItems", () => {
           driver: "postgres",
           capabilities: { schemas: true },
           schemas,
+          selectedSchemas: schemas,
           schemaDataMap,
           databaseDataMap,
           tables: [],
@@ -126,6 +127,42 @@ describe("useCommandPaletteObjectItems", () => {
     expect(replacementLoadSchemaData).toHaveBeenCalledOnce();
   });
 
+  it("should only load the schemas selected in the explorer", () => {
+    const loadSchemaData = vi.fn();
+    vi.mocked(useDatabase).mockImplementation(
+      () =>
+        ({
+          activeConnectionId: "connection-1",
+          connectionDataMap: {
+            "connection-1": {
+              driver: "postgres",
+              capabilities: { schemas: true },
+              schemas: ["public", "topology", "tiger"],
+              selectedSchemas: ["public"],
+              schemaDataMap: {},
+              databaseDataMap: {},
+              tables: [],
+              views: [],
+              routines: [],
+              triggers: [],
+              activeSchema: "public",
+            },
+          },
+          connections: [
+            { id: "connection-1", params: { database: "app" } },
+          ],
+          loadDatabaseData: vi.fn(),
+          loadSchemaData,
+          setActiveTable: vi.fn(),
+        }) as unknown as ReturnType<typeof useDatabase>,
+    );
+
+    renderHook(() => useCommandPaletteObjectItems(vi.fn(), vi.fn()));
+
+    expect(loadSchemaData).toHaveBeenCalledTimes(1);
+    expect(loadSchemaData).toHaveBeenCalledWith("public", "connection-1");
+  });
+
   it("should report the schemas it gave up on instead of dropping them silently", () => {
     const failingSchema = {
       tables: [],
@@ -144,6 +181,7 @@ describe("useCommandPaletteObjectItems", () => {
               driver: "postgres",
               capabilities: { schemas: true },
               schemas: ["billing"],
+              selectedSchemas: ["billing"],
               // A failed load resets the entry to neither loading nor loaded.
               schemaDataMap: { billing: { ...failingSchema } },
               databaseDataMap: {},
@@ -197,6 +235,7 @@ describe("useCommandPaletteObjectItems", () => {
               driver: "postgres",
               capabilities: { schemas: true },
               schemas: ["billing"],
+              selectedSchemas: ["billing"],
               schemaDataMap,
               databaseDataMap: {},
               tables: [],

--- a/tests/utils/objectPaletteItems.test.ts
+++ b/tests/utils/objectPaletteItems.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   createObjectPaletteItems,
+  OBJECT_TYPE_RELEVANCE,
   type ObjectPaletteRuntime,
 } from "../../src/utils/objectPaletteItems";
 import type { NavigatorItem } from "../../src/utils/quickNavigator";
@@ -157,5 +158,56 @@ describe("createObjectPaletteItems", () => {
 
     expect(runtime.navigateToEditor).toHaveBeenCalled();
     expect(runtime.setActiveTable).not.toHaveBeenCalled();
+  });
+
+  it("should rank tables above views and views above routines and triggers", () => {
+    const navigatorItems: NavigatorItem[] = [
+      {
+        type: "routine",
+        name: "fn",
+        schema: "public",
+        item: { name: "fn", routine_type: "FUNCTION" },
+      },
+      {
+        type: "trigger",
+        name: "trg",
+        schema: "public",
+        item: {
+          name: "trg",
+          table_name: "orders",
+          event: "INSERT",
+          timing: "AFTER",
+        },
+      },
+      {
+        type: "view",
+        name: "v",
+        schema: "public",
+        item: { name: "v" },
+      },
+      {
+        type: "table",
+        name: "t",
+        schema: "public",
+        item: { name: "t" },
+      },
+    ];
+
+    const relevance = Object.fromEntries(
+      createObjectPaletteItems({
+        navigatorItems,
+        connectionId: "connection-a",
+        driver: "postgres",
+        hasGroups: true,
+        isMultiDatabase: false,
+        labels,
+        runtime: createRuntime(),
+      }).map((item) => [item.icon, item.relevance]),
+    );
+
+    expect(relevance).toEqual(OBJECT_TYPE_RELEVANCE);
+    expect(relevance.table).toBeGreaterThan(relevance.view);
+    expect(relevance.view).toBeGreaterThan(relevance.routine);
+    expect(relevance.view).toBeGreaterThan(relevance.trigger);
   });
 });

--- a/tests/utils/objectPaletteItems.test.ts
+++ b/tests/utils/objectPaletteItems.test.ts
@@ -36,6 +36,69 @@ function createRuntime(): ObjectPaletteRuntime {
 }
 
 describe("createObjectPaletteItems", () => {
+  it("should collapse overloaded routines but keep distinct triggers apart", () => {
+    const navigatorItems: NavigatorItem[] = [
+      {
+        type: "routine",
+        name: "approx_percentile",
+        schema: "public",
+        item: { name: "approx_percentile", routine_type: "FUNCTION" },
+      },
+      {
+        type: "routine",
+        name: "approx_percentile",
+        schema: "public",
+        item: { name: "approx_percentile", routine_type: "FUNCTION" },
+      },
+      {
+        type: "routine",
+        name: "approx_percentile",
+        schema: "public",
+        item: { name: "approx_percentile", routine_type: "PROCEDURE" },
+      },
+      {
+        type: "trigger",
+        name: "set_updated_at",
+        schema: "public",
+        item: {
+          name: "set_updated_at",
+          table_name: "users",
+          event: "UPDATE",
+          timing: "BEFORE",
+        },
+      },
+      {
+        type: "trigger",
+        name: "set_updated_at",
+        schema: "public",
+        item: {
+          name: "set_updated_at",
+          table_name: "orders",
+          event: "UPDATE",
+          timing: "BEFORE",
+        },
+      },
+    ];
+
+    const items = createObjectPaletteItems({
+      navigatorItems,
+      connectionId: "connection-a",
+      driver: "postgres",
+      hasGroups: true,
+      isMultiDatabase: false,
+      labels,
+      runtime: createRuntime(),
+    });
+
+    expect(items.map((item) => item.title)).toEqual([
+      "approx_percentile",
+      "approx_percentile",
+      "set_updated_at",
+      "set_updated_at",
+    ]);
+    expect(new Set(items.map((item) => item.id)).size).toBe(4);
+  });
+
   it("should bind table actions to the complete target", async () => {
     const runtime = createRuntime();
     const navigatorItems: NavigatorItem[] = [

--- a/tests/utils/paletteItems.test.ts
+++ b/tests/utils/paletteItems.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { PaletteItem } from "../../src/types/palette";
-import { createPaletteSearch } from "../../src/utils/paletteItems";
+import {
+  createPaletteSearch,
+  MAX_VISIBLE_PALETTE_RESULTS,
+} from "../../src/utils/paletteItems";
 
 function createItem(
   overrides: Partial<PaletteItem> = {},
@@ -86,5 +89,68 @@ describe("createPaletteSearch", () => {
       "public-user-roles",
       "sales-user",
     ]);
+  });
+
+  it("should not let a short query fuzzy-match every function in a large schema", () => {
+    const routines = Array.from({ length: 200 }, (_, index) =>
+      createItem({
+        id: `routine-${index}`,
+        title: `st_setsrid_${index}`,
+        description: "FUNCTION",
+        group: "public",
+        badge: "Routine",
+      }),
+    );
+    const search = createPaletteSearch([
+      createItem({
+        id: "users",
+        title: "users",
+        group: "public",
+        badge: "Table",
+      }),
+      ...routines,
+    ]);
+
+    expect(search("users").map((item) => item.id)).toEqual(["users"]);
+    // A single typo still matches.
+    expect(search("usrs").map((item) => item.id)).toEqual(["users"]);
+  });
+
+  it("should rank a boosted table above loosely matching routines but below an exact routine", () => {
+    const search = createPaletteSearch([
+      createItem({
+        id: "routine-loose",
+        title: "st_equals",
+        relevance: 0,
+      }),
+      createItem({
+        id: "table",
+        title: "sequences",
+        relevance: 20,
+      }),
+      createItem({
+        id: "routine-exact",
+        title: "seqences_next",
+        relevance: 0,
+      }),
+    ]);
+
+    // Both the table and the routine contain the query verbatim; the boost
+    // puts the table first, and the routine that only matches fuzzily is
+    // dropped by the threshold.
+    expect(search("seq").map((item) => item.id)).toEqual([
+      "table",
+      "routine-exact",
+    ]);
+    // A verbatim routine match still beats a table that only matches with a
+    // typo.
+    expect(search("seqences").map((item) => item.id)).toEqual([
+      "routine-exact",
+      "table",
+    ]);
+  });
+
+  it("should expose a render cap that keeps large lists responsive", () => {
+    expect(MAX_VISIBLE_PALETTE_RESULTS).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Problem

A user reported that the quick navigator on their Postgres database shows about 1.6k entries for a schema with roughly 300 tables, that typing a table name does not filter the functions away, and that the search lags.

The extra entries come from extension functions (PostGIS alone adds over a thousand to `public`). Three things in the palette made that hard to live with:

- Tables, views, routines and triggers all had the same weight, so functions ranked between tables.
- The Fuse threshold of 0.4 allows two edits on a five letter query. With 1300 function names in the index that keeps most of them in the list. In a quick probe with PostGIS-like names, `users` returned 218 matches, 217 of them functions.
- Every match was rendered on each keystroke with no upper bound, including all 1.6k rows when the palette opens with an empty query.

## Changes

- `objectPaletteItems.ts`: each object gets a `relevance` from `OBJECT_TYPE_RELEVANCE` (table 20, view 10, routine and trigger 0). With an empty query tables come first. With a query, a table containing the text ranks above functions, but typing the exact name of a function still puts that function first, since the boost stays well below the score of a verbatim match.
- `paletteItems.ts`: threshold lowered from 0.4 to 0.3. That still tolerates one typo every four characters (the existing `preferenses` test keeps passing). Adds `MAX_VISIBLE_PALETTE_RESULTS`.
- `Palette.tsx`: renders at most 100 rows. The footer still shows the total match count so nothing looks missing.

The threshold change also applies to the command palette, since both share `createPaletteSearch`.

## Tests

New cases cover the type ranking, the tighter threshold against a large set of function names, exact routine match beating a typo'd table, tables-first ordering on an empty query, and the render cap. Full suite passes (236 files, 3906 tests), plus `pnpm typecheck` and eslint on the touched files.

## Not in this PR

- Filtering extension-owned functions out of the Postgres routine list (via `pg_depend`). It would shrink the sidebar as well, so it deserves its own discussion.
- A boost for the active schema.
