### PR TITLE
ci: add label-driven PR preview builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,18 @@
 name: Build
 
-# Reusable build matrix used by nightly.yml (cron) and release.yml (tags).
-# Centralises the signing/notarization config in one place so callers can't
-# drift from it.
+# Reusable build matrix used by nightly.yml (cron), release.yml (tags) and
+# preview.yml (maintainer-requested PR builds). Centralises the
+# signing/notarization config in one place so callers can't drift from it.
+#
+# Two modes:
+#   * release (default): signed + notarized bundles uploaded as assets of the
+#     GitHub Release `tag`, created if missing.
+#   * preview: `preview: true`. Bundles uploaded as workflow-run artifacts
+#     only: no release, no tag, no updater artifacts. Signed + notarized when
+#     the signing secrets are available, unsigned (with a warning) when they
+#     are not. That is what makes the fork rule work: on a `pull_request`
+#     event GitHub hands secrets only to PRs from this repository, so preview
+#     builds of fork PRs come out unsigned without any extra logic here.
 on:
   workflow_call:
     inputs:
@@ -11,9 +21,15 @@ on:
         required: true
         type: string
       tag:
-        description: "Release tag to create/upload to."
-        required: true
+        description: "Release tag to create/upload to. Ignored (and may be empty) when `preview` is true."
+        required: false
+        default: ""
         type: string
+      preview:
+        description: "Upload the bundles as run artifacts instead of a GitHub Release."
+        required: false
+        default: false
+        type: boolean
       release_name:
         description: "Release title. Supports tauri-action's __VERSION__ placeholder."
         required: false
@@ -47,18 +63,23 @@ on:
 
 jobs:
   publish-tauri:
-    permissions:
-      contents: write
+    # Permissions are inherited from the caller: release/nightly grant
+    # `contents: write` (release upload), preview grants only `contents: read`.
+    # A called workflow can't request more than the caller grants, so they
+    # can't be declared here without breaking one of the two modes.
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: "macos-latest" # for Arm64
             args: "--target aarch64-apple-darwin"
+            artifact: macos-arm64
           - platform: "macos-15-intel" # for Intel
             args: "--target x86_64-apple-darwin"
+            artifact: macos-x64
           - platform: "ubuntu-24.04"
             args: ""
+            artifact: linux-x64
             # Build inside an ubuntu:22.04 container (glibc 2.35) rather than
             # on the bare ubuntu-24.04 runner (glibc 2.39), so the produced
             # .deb/.AppImage keep running on older LTS distros. Pinned to the
@@ -67,6 +88,7 @@ jobs:
             container: "ubuntu:22.04"
           - platform: "windows-latest"
             args: ""
+            artifact: windows-x64
 
     runs-on: ${{ matrix.platform }}
     container: ${{ matrix.container }}
@@ -163,14 +185,43 @@ jobs:
           EOF
           chmod +x ~/.cache/tauri/linuxdeploy-plugin-gtk.sh
 
+      # Signing/notarization needs the whole set; a partial set would make
+      # tauri fail half-way, and a set-but-empty APPLE_SIGNING_IDENTITY is
+      # taken by tauri as an identity to sign with. Hence the two build steps
+      # below: the signed one defines the variables, the unsigned one doesn't.
+      - name: Detect signing secrets
+        shell: bash
+        env:
+          HAS_SECRETS: ${{ secrets.APPLE_CERTIFICATE != '' && secrets.APPLE_SIGNING_IDENTITY != '' && secrets.APPLE_API_KEY_CONTENT != '' && secrets.TAURI_PRIVATE_KEY != '' }}
+          PREVIEW: ${{ inputs.preview }}
+        run: |
+          echo "CAN_SIGN=$HAS_SECRETS" >> "$GITHUB_ENV"
+          if [ "$HAS_SECRETS" != "true" ]; then
+            if [ "$PREVIEW" = "true" ]; then
+              echo "::warning::Signing secrets unavailable (fork PR?) — this preview bundle will NOT be signed nor notarized."
+            else
+              echo "::error::Release builds require the signing secrets; refusing to publish unsigned bundles."
+              exit 1
+            fi
+          fi
+
       # Notarization needs the App Store Connect API key on disk. The .p8 is stored
       # base64-encoded in APPLE_API_KEY_CONTENT and decoded into a temp file (macOS only).
       - name: Prepare Apple API key (macOS only)
-        if: startsWith(matrix.platform, 'macos')
+        if: startsWith(matrix.platform, 'macos') && env.CAN_SIGN == 'true'
         shell: bash
         run: |
           echo "${{ secrets.APPLE_API_KEY_CONTENT }}" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
           echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/apple_api_key.p8" >> "$GITHUB_ENV"
+
+      # Preview builds are never served through latest.json, so the updater
+      # bundles + .sig files would only be noise; and `createUpdaterArtifacts`
+      # makes `tauri build` demand the updater key, which fork PRs don't have.
+      - name: Disable updater artifacts (preview)
+        if: inputs.preview
+        shell: bash
+        run: |
+          node -e "const f='src-tauri/tauri.conf.json';const c=require('./'+f);const fs=require('fs');c.bundle.createUpdaterArtifacts=false;fs.writeFileSync(f, JSON.stringify(c, null, 2)+'\n');"
 
       - name: Override app version (nightly channel)
         if: inputs.updater_version != ''
@@ -184,7 +235,9 @@ jobs:
           sed -i.bak "0,/^version = \".*\"/s//version = \"$v\"/" src-tauri/Cargo.toml && rm -f src-tauri/Cargo.toml.bak
           echo "Patched version to $v"
 
-      - uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
+      - name: Build signed bundles (+ upload to GitHub Release unless preview)
+        if: env.CAN_SIGN == 'true'
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_BUNDLER_NEW_APPIMAGE_FORMAT: ${{ inputs.experimental_appimage && 'true' || '' }}
@@ -199,7 +252,9 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
         with:
-          tagName: ${{ inputs.tag }}
+          # Without a tagName tauri-action only builds and never touches
+          # releases, which is exactly what preview mode wants.
+          tagName: ${{ !inputs.preview && inputs.tag || '' }}
           releaseName: ${{ inputs.release_name }}
           releaseBody: ${{ inputs.release_body }}
           releaseDraft: ${{ inputs.draft }}
@@ -208,8 +263,19 @@ jobs:
           tauriScript: ${{ inputs.experimental_appimage && matrix.platform == 'ubuntu-24.04' && 'cargo tauri' || 'pnpm tauri' }}
           args: ${{ matrix.args }}
 
+      - name: Build unsigned bundles (preview without secrets)
+        if: env.CAN_SIGN != 'true'
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_BUNDLER_NEW_APPIMAGE_FORMAT: ${{ inputs.experimental_appimage && 'true' || '' }}
+        with:
+          # No tagName: tauri-action only builds, it never touches releases.
+          tauriScript: ${{ inputs.experimental_appimage && matrix.platform == 'ubuntu-24.04' && 'cargo tauri' || 'pnpm tauri' }}
+          args: ${{ matrix.args }}
+
       - name: Upload portable executable (Windows only)
-        if: matrix.platform == 'windows-latest'
+        if: matrix.platform == 'windows-latest' && !inputs.preview
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -219,3 +285,27 @@ jobs:
           $portable = "tabularis_${version}_x64-portable.exe"
           Copy-Item $src $portable
           gh release upload "${{ inputs.tag }}" $portable --clobber
+
+      - name: Stage portable executable (Windows only, preview mode)
+        if: matrix.platform == 'windows-latest' && inputs.preview
+        shell: pwsh
+        run: |
+          $version = (Get-Content src-tauri\tauri.conf.json -Raw | ConvertFrom-Json).version
+          Copy-Item "src-tauri\target\release\tabularis.exe" "src-tauri\target\release\bundle\tabularis_${version}_x64-portable.exe"
+
+      # Only the installable bundles: the raw .app directory, the deb/rpm
+      # staging trees and the binaries themselves are noise for a tester.
+      - name: Upload preview artifacts
+        if: inputs.preview
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tabularis-preview-${{ matrix.artifact }}
+          path: |
+            src-tauri/target/**/release/bundle/**/*.dmg
+            src-tauri/target/**/release/bundle/**/*.deb
+            src-tauri/target/**/release/bundle/**/*.rpm
+            src-tauri/target/**/release/bundle/**/*.AppImage
+            src-tauri/target/**/release/bundle/**/*.msi
+            src-tauri/target/**/release/bundle/**/*.exe
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -1,0 +1,102 @@
+name: Preview Comment
+
+# Second half of preview.yml: once a preview build finishes, post (or update)
+# a single sticky comment on the PR linking the artifacts of that run.
+#
+# Split off via workflow_run because the build runs in the PR's context,
+# where a fork PR only gets a read-only token. This workflow runs on the
+# default branch with its own token and never executes PR code, so granting
+# it `pull-requests: write` is safe.
+on:
+  workflow_run:
+    workflows: ["Preview Build"]
+    types: [completed]
+
+jobs:
+  comment:
+    # Cancelled runs were superseded by a newer push; that one will comment.
+    # Skipped builds (label event for another label) conclude "success" with
+    # no artifacts and are filtered out below.
+    if: github.event.workflow_run.conclusion != 'cancelled'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read # list artifacts
+      pull-requests: write
+    steps:
+      - name: Upsert the preview comment on the PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          # workflow_run.pull_requests is empty for fork PRs, so the PR is
+          # looked up from the commit instead; this tells signed from unsigned.
+          IS_FORK: ${{ github.event.workflow_run.head_repository.full_name != github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          artifacts=$(gh api --paginate "repos/$GH_REPO/actions/runs/$RUN_ID/artifacts" \
+            --jq '.artifacts[] | select(.name | startswith("tabularis-preview-")) | [.name, .id, .size_in_bytes, .expires_at] | @tsv' | sort)
+          if [ -z "$artifacts" ] && [ "$CONCLUSION" = "success" ]; then
+            echo "Run $RUN_ID built nothing (not a preview request) — no comment to post."
+            exit 0
+          fi
+
+          pr=$(gh api "repos/$GH_REPO/commits/$SHA/pulls" \
+            --jq '[.[] | select(.state == "open")] | .[0].number // empty')
+          if [ -z "$pr" ]; then
+            echo "No open PR for $SHA — nothing to comment on."
+            exit 0
+          fi
+          short=${SHA:0:7}
+          marker="<!-- tabularis-preview-build -->"
+
+          {
+            echo "$marker"
+            echo "### Preview build"
+            echo
+            if [ "$CONCLUSION" = "success" ]; then
+              echo "Test builds of commit \`$short\` ([workflow run]($RUN_URL))."
+              echo
+              echo "| Platform | Download | Size |"
+              echo "|---|---|---|"
+              expires=""
+              while IFS=$'\t' read -r name id size exp; do
+                case "$name" in
+                  *macos-arm64) platform="macOS (Apple Silicon)" ;;
+                  *macos-x64)   platform="macOS (Intel)" ;;
+                  *linux-x64)   platform="Linux (.deb / .rpm / AppImage)" ;;
+                  *windows-x64) platform="Windows (.msi / setup / portable)" ;;
+                  *)            platform="$name" ;;
+                esac
+                printf '| %s | [%s](https://github.com/%s/actions/runs/%s/artifacts/%s) | %d MB |\n' \
+                  "$platform" "$name" "$GH_REPO" "$RUN_ID" "$id" "$(( (size + 524287) / 1048576 ))"
+                expires=${exp:0:10}
+              done <<< "$artifacts"
+              echo
+              echo "> **Note:** you need to be logged in to GitHub to download the archives; they expire on ${expires:-14 days from now}."
+              echo ">"
+              if [ "$IS_FORK" = "true" ]; then
+                echo "> This PR comes from a fork, so these builds are **not signed**. macOS will say the app is damaged: run \`xattr -cr /Applications/tabularis.app\` after copying it, or right-click → Open. Windows SmartScreen: *More info → Run anyway*."
+              else
+                echo "> Windows SmartScreen may warn about an unrecognised app: *More info → Run anyway*."
+              fi
+              echo ">"
+              echo "> Rebuilt on every push while the \`preview\` label is on this PR."
+            else
+              echo "The preview build of commit \`$short\` **failed** ($CONCLUSION). See the [workflow run]($RUN_URL) for logs."
+            fi
+          } > body.md
+
+          existing=$(gh api --paginate "repos/$GH_REPO/issues/$pr/comments" \
+            --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1)
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$GH_REPO/issues/comments/$existing" -F body=@body.md --silent
+            echo "Updated comment $existing on PR #$pr."
+          else
+            gh pr comment "$pr" --body-file body.md
+            echo "Posted new comment on PR #$pr."
+          fi

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,45 @@
+name: Preview Build
+
+# Preview builds of a pull request, so the person who reported a bug can test
+# the fix before it ships in a nightly. Modelled on Zed's `run-bundling`
+# label (zed-industries/zed, .github/workflows/run_bundling.yml).
+#
+# A maintainer adds the `preview` label to the PR: that builds the PR head
+# right away, and every later push rebuilds it for as long as the label stays.
+# Remove the label to stop. Adding a label needs triage permission on the
+# repo, which is the whole access control, as in Zed.
+#
+# Signing follows GitHub's own rule for `pull_request` events: PRs from
+# branches of this repository get the secrets and come out signed +
+# notarized like a release; PRs from forks get no secrets and come out
+# unsigned (build.yml warns in the log). Nothing here decides that.
+#
+# The bundles end up as artifacts of this run, never in the Releases page;
+# preview-comment.yml then links them from a sticky comment on the PR (it
+# needs a separate workflow_run workflow because a fork PR's token can't
+# write comments).
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: |-
+      (github.event.action == 'labeled' && github.event.label.name == 'preview') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'preview'))
+    permissions:
+      contents: read # artifacts only, the token can't touch releases
+    uses: ./.github/workflows/build.yml
+    # Inherited from the caller's context: full set for in-repo PRs, empty for
+    # fork PRs. build.yml picks signed/unsigned accordingly.
+    secrets: inherit
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+      preview: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
   - [Reporting Bugs](#reporting-bugs)
   - [Suggesting Enhancements](#suggesting-enhancements)
   - [Your First Code Contribution](#your-first-code-contribution)
+  - [Testing a Pull Request Build](#testing-a-pull-request-build)
   - [Improving The Documentation](#improving-the-documentation)
 - [Styleguides](#styleguides)
   - [Commit Messages](#commit-messages)
@@ -146,6 +147,12 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/Tabula
 include Setup of env, IDE and typical getting started instructions?
 
 -->
+
+### Testing a Pull Request Build
+
+Maintainers can add the `preview` label to a pull request to get installable builds of it for macOS, Linux and Windows, without publishing anything to the Releases page. The build runs right away and again on every push while the label stays; a bot comment on the PR links the downloads (a GitHub login is required, and they expire after 14 days). Builds of PRs from forks are not signed, so macOS asks for `xattr -cr` on the app and Windows shows a SmartScreen warning.
+
+If you reported a bug and a maintainer points you to such a build, that is the fastest way to confirm the fix before it lands in a nightly.
 
 ### Improving The Documentation
 


### PR DESCRIPTION
## What changed

Adds a way to hand a build of a pull request to whoever needs to test it, without publishing anything to the Releases page.

A maintainer adds the `preview` label to a PR. The `Preview Build` workflow builds the PR head for macOS (arm64 and x64), Linux and Windows, uploads the installable bundles as run artifacts (14 days retention), and rebuilds on every push for as long as the label stays. A second workflow, `Preview Comment`, posts a single sticky comment on the PR with a download link per platform, size and expiry date, and updates it after every rebuild. The design follows Zed's `run-bundling` label.

- `.github/workflows/build.yml`: new `preview` input. In preview mode tauri-action runs without a tag, so it only builds and never touches releases; updater artifacts are disabled since they are never served through `latest.json`; the bundles (dmg, deb, rpm, AppImage, msi, setup exe and the Windows portable exe) are uploaded with `actions/upload-artifact`. A new step checks whether the signing secrets are present: when they are, the existing signed and notarized path runs; when they are not, an unsigned build runs instead, with a warning in the log. The two paths are separate steps because tauri treats a set-but-empty `APPLE_SIGNING_IDENTITY` as an identity to sign with. Release mode now fails explicitly when the secrets are missing instead of publishing unsigned bundles. The job-level `permissions` block was removed: a called workflow cannot request more than the caller grants, and preview only grants `contents: read`, so callers (release, nightly, preview) declare it themselves.
- `.github/workflows/preview.yml`: `pull_request` on `labeled` and `synchronize`, gated on the `preview` label, calling `build.yml` with `secrets: inherit` and `contents: read`.
- `.github/workflows/preview-comment.yml`: `workflow_run` on `Preview Build`. It resolves the PR from the head commit (the payload has no PR number for fork PRs), lists the run artifacts and creates or updates the comment. It runs on the default branch with its own token and never executes PR code, which is why it can hold `pull-requests: write`.
- `CONTRIBUTING.md`: short section explaining the label to contributors and to people who reported a bug.

Signing follows GitHub's own rule for `pull_request` events: PRs from branches of this repository receive the secrets and come out signed and notarized like a release; PRs from forks receive none and come out unsigned. The comment tells the tester which case applies and how to open an unsigned app. Nothing in the workflows decides this, so no new trust is extended to fork code.

Access control is the label itself: adding one requires triage permission on the repository.

## Verification

- `actionlint` passes on all three workflows.
- Release and nightly paths are unchanged in behaviour: same signed step, same `tagName`, same portable upload, only now behind `if` conditions that evaluate to the old values when `preview` is false.
- A real preview build cannot run before merge, since `pull_request` workflows are taken from the base branch. Plan after merge: label a small in-repo PR to check the signed path and the comment, then a fork PR to check the unsigned path.

## Follow-up

The `preview` label already exists on the repository; its description ("Build unsigned preview artifacts for this PR") should be updated, since only fork builds are unsigned now.
