### PR TITLE
fix(test): bind storage globals to the jsdom environment

### DIFF
--- a/.rules/testing.md
+++ b/.rules/testing.md
@@ -161,3 +161,12 @@ Tests are configured in `vitest.config.ts`:
 - Test files are discovered in `tests/` directory
 - Setup file: `./tests/setup.ts`
 - Environment: `jsdom` for DOM-related tests
+
+### Browser storage in the test environment
+
+`tests/setup.ts` binds `localStorage` and `sessionStorage` to the current
+Vitest jsdom window before test modules load. Keep this shared setup: Node's
+native storage globals can otherwise shadow jsdom, yielding unavailable or
+non-browser storage. Do not work around it with per-test storage shims or a
+shared `--localstorage-file`. `tests/storageEnvironment.test.ts` verifies the
+real DOM storage identity, separate stores, and restoration after global stubs.

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,7 +1,18 @@
+/// <reference types="vitest/jsdom" />
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 import { vi } from "vitest";
+
+// Node's native storage globals can prevent Vitest from installing jsdom's.
+// Bind both APIs before test modules load, using this worker's real DOM storage.
+for (const name of ["localStorage", "sessionStorage"] as const) {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value: jsdom.window[name],
+  });
+}
 
 // Cleanup after each test
 afterEach(() => {

--- a/tests/storageEnvironment.test.ts
+++ b/tests/storageEnvironment.test.ts
@@ -1,0 +1,45 @@
+/// <reference types="vitest/jsdom" />
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Capture during module evaluation, before any test hooks can repair the globals.
+const initialStorage = {
+  localStorage: globalThis.localStorage,
+  sessionStorage: globalThis.sessionStorage,
+};
+
+describe("jsdom storage environment", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    jsdom.window.localStorage.clear();
+    jsdom.window.sessionStorage.clear();
+  });
+
+  it.each(["localStorage", "sessionStorage"] as const)(
+    "%s uses this test environment's browser storage before test imports",
+    (name) => {
+      const storage = initialStorage[name];
+      expect(storage).toBe(jsdom.window[name]);
+      expect(storage).toBeInstanceOf(jsdom.window.Storage);
+      storage.setItem("storage-regression", "value");
+      expect(window[name].getItem("storage-regression")).toBe("value");
+      expect(storage.key(0)).toBe("storage-regression");
+      storage.removeItem("storage-regression");
+      expect(storage.length).toBe(0);
+    },
+  );
+
+  it("keeps local and session storage separate", () => {
+    localStorage.setItem("shared-key", "local");
+    sessionStorage.setItem("shared-key", "session");
+    localStorage.clear();
+    expect(sessionStorage.getItem("shared-key")).toBe("session");
+  });
+
+  it("restores browser storage after a test replaces a global", () => {
+    vi.stubGlobal("localStorage", undefined);
+    vi.stubGlobal("sessionStorage", undefined);
+    vi.unstubAllGlobals();
+    expect(localStorage).toBe(jsdom.window.localStorage);
+    expect(sessionStorage).toBe(jsdom.window.sessionStorage);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #713.

Node's native Web Storage globals can keep Vitest from installing jsdom's storage. On the unchanged checkout under Node 26.0.0, all 40 tests in the three reported files fail at `localStorage.clear()`.

Bind `localStorage` and `sessionStorage` to the current worker's actual `jsdom.window` in shared setup, before test modules load. This preserves real browser Storage behavior and avoids per-file mocks or a shared Node storage file. Four regression cases verify both APIs at module evaluation, separate stores, and restoration after global stubs. The testing rules document the setup invariant.

## Validation
- Before: 40/40 reported tests failed; all four new regression cases failed.
- After, Node 26.0.0: full frontend suite passed, **244 files / 3,973 tests**.
- Pinned Node 24.18.0: all **44 targeted tests** passed.
- `pnpm run typecheck` and `pnpm run build` passed.
- `pnpm run lint` passed with one existing `ThemeProvider.tsx:342` exhaustive-deps warning in an unchanged file.
- `git diff --cached --check` passed. GitNexus impact/detect-changes ran; top-level setup has no resolved call-graph edges, so validation covered the complete frontend suite instead of assuming no impact.

The Rust backend and native application runtime are unchanged and were not tested for this harness-only change.

## AI disclosure
Implemented and validated using OpenAI Codex, submitted by be-student. No human review has been performed.
