### PR TITLE
fix(linux): preserve deep links in desktop entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ chmod +x tabularis_x.x.x_amd64.AppImage
 ./tabularis_x.x.x_amd64.AppImage
 ```
 
+The `.deb` and AppImage desktop entry registers `tabularis://` links and forwards the
+URL when launching Tabularis, including on a cold start.
+
 ### Arch Linux (AUR)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ chmod +x tabularis_x.x.x_amd64.AppImage
 ./tabularis_x.x.x_amd64.AppImage
 ```
 
-The `.deb` and AppImage desktop entry registers `tabularis://` links and forwards the
-URL when launching Tabularis, including on a cold start.
+The `.deb` desktop entry registers `tabularis://` links and forwards the URL when
+launching Tabularis, including on a cold start.
 
 ### Arch Linux (AUR)
 

--- a/src-tauri/deb/tabularis.desktop
+++ b/src-tauri/deb/tabularis.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Categories={{{categories}}}
+Comment={{{comment}}}
+Exec={{{exec}}} %u
+Icon={{{icon}}}
+Name=Tabularis
+StartupWMClass=tabularis
+Terminal=false
+Type=Application
+MimeType=x-scheme-handler/tabularis;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,6 +35,7 @@
     "createUpdaterArtifacts": true,
     "active": true,
     "targets": "all",
+    "category": "DeveloperTool",
     "icon": [
       "icons/32x32.png",
       "icons/64x64.png",
@@ -46,6 +47,7 @@
     ],
     "linux": {
       "deb": {
+        "desktopTemplate": "deb/tabularis.desktop",
         "depends": [
           "libwebkit2gtk-4.1-0",
           "libsecret-1-0"

--- a/tests/config/debDesktopEntry.test.ts
+++ b/tests/config/debDesktopEntry.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repositoryRoot = resolve(import.meta.dirname, '../..');
+const tauriConfig = JSON.parse(
+  readFileSync(resolve(repositoryRoot, 'src-tauri/tauri.conf.json'), 'utf8'),
+);
+
+describe('Debian desktop entry', () => {
+  it('preserves the deep-link URL and stable application identity', () => {
+    expect(tauriConfig.productName).toBe('tabularis');
+    expect(tauriConfig.bundle.category).toBe('DeveloperTool');
+    expect(tauriConfig.bundle.linux.deb.desktopTemplate).toBe('deb/tabularis.desktop');
+
+    const template = readFileSync(
+      resolve(repositoryRoot, 'src-tauri', tauriConfig.bundle.linux.deb.desktopTemplate),
+      'utf8',
+    );
+
+    expect(template).toContain('Name=Tabularis\n');
+    expect(template).toContain('StartupWMClass=tabularis\n');
+    expect(template).toContain('Exec={{{exec}}} %u\n');
+    expect(template).toContain('Categories={{{categories}}}\n');
+    expect(template).toContain('MimeType=x-scheme-handler/tabularis;\n');
+
+    const placeholders = [...template.matchAll(/\{\{\{(\w+)\}\}\}/g)].map(
+      ([, name]) => name,
+    );
+    expect(placeholders.sort()).toEqual(['categories', 'comment', 'exec', 'icon']);
+  });
+});


### PR DESCRIPTION
## Changes

Fixes #671.

- Set the Tauri bundle category to `DeveloperTool`, which supplies the Linux `Development` category while also providing the correct application category on other platforms.
- Add a Debian desktop template that keeps the lowercase executable identity but displays `Name=Tabularis`, passes cold-start deep-link URLs through `Exec={{{exec}}} %u`, and registers the `tabularis://` scheme.
- Add a packaging contract test that protects the config path, supported Handlebars variables, desktop identity, URL field code, and MIME registration.
- Document Linux cold-start link forwarding in the README.

## Verification

- Pre-fix regression: `pnpm test --run tests/config/debDesktopEntry.test.ts` failed because `bundle.category` and the custom template were absent.
- `pnpm test --run tests/config/debDesktopEntry.test.ts` — 1 passed.
- `pnpm build` — passed (3,681 modules transformed).
- `pnpm typecheck` — passed.
- `pnpm lint` — passed with one existing `react-hooks/exhaustive-deps` warning in `src/contexts/ThemeProvider.tsx`.
- `pnpm tauri info` — parsed the configuration and detected the expected Tauri bundle and deep-link plugin; local Rust binaries were unavailable to build a Debian artifact on this macOS host.
- `pnpm exec gitnexus detect-changes --scope staged --repo tabularis` — low risk, no affected execution flows.
- Full `pnpm test --run` baseline: 3,930 passed; 40 known localStorage failures from #713 remain and are addressed separately by #719.
- `git diff --check` — passed.

## Agent Disclosure

This pull request was generated and validated by OpenAI Codex. The submitting account is operated by @be-student; no human code review was performed before submission.
