### PR TITLE
chore(skills): add Codex metadata for tabularis-pr-review and drop stray .codex file

### DIFF
--- a/.claude/skills/tabularis-pr-review/agents/openai.yaml
+++ b/.claude/skills/tabularis-pr-review/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Tabularis PR Review"
+  short_description: "Review a Tabularis PR locally against repo rules with real test data."
+  default_prompt: "Use $tabularis-pr-review to review PR #N: check the diff against .rules/, verify the PR's claims, run its tests on the PR branch, and prepare real test data plus a manual test plan."
+
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
## What changed

- Added `.claude/skills/tabularis-pr-review/agents/openai.yaml` with the display name, short description and default prompt Codex uses in its skills menu. The skill was already discovered by Codex and pi through the `.agents/skills` symlink, but it was the only Tabularis skill without this metadata (`tabularis-plugin-driver` already ships one).
- Removed the empty `.codex` file at the repo root. It was committed by accident in 5b6052bd, nothing references it, and it shadows a real `.codex/` project config directory.

## Verification

- `codex debug prompt-input` from the repo root lists `tabularis-pr-review` among the available skills.
- `grep` across the repo finds no reference to the `.codex` file.