### PR TITLE
Fix lost keystrokes in the SQL editor: backward selection on WebKit and debounce race

### DIFF
--- a/src/components/ui/SqlEditorWrapper.tsx
+++ b/src/components/ui/SqlEditorWrapper.tsx
@@ -54,6 +54,9 @@ function isLinux(): boolean {
   return platform.toUpperCase().includes("LINUX");
 }
 
+/** Debounced onChange emissions remembered until the consumer echoes them back. */
+const MAX_PENDING_ECHOES = 50;
+
 // Internal component that resets when key changes
 const SqlEditorInternal = ({
   initialValue,
@@ -113,11 +116,34 @@ const SqlEditorInternal = ({
     };
   }, []);
 
-  // Sync editor value only when initialValue changes externally (e.g., tab switch)
-  // Preserve cursor position to avoid jumping to start during debounced updates
+  // Values handed to onChange that the consumer has not echoed back through
+  // initialValue yet. Bounded because a consumer may drop updates (Editor.tsx
+  // ignores onChange from inactive tabs).
+  const pendingEchoesRef = useRef<string[]>([]);
+
+  // Sync editor value only when initialValue changes externally (e.g., a saved
+  // query loaded into the tab). Preserve cursor position to avoid jumping to
+  // start.
+  //
+  // The debounced onChange flush re-renders the consumer asynchronously, so by
+  // the time initialValue comes back it can already be stale: keystrokes typed
+  // in between are in the editor but not in initialValue. Writing it back with
+  // setValue would drop them (#731), so an echo of our own emission is never
+  // applied. Anything else is an external change and wins over pending edits.
   useEffect(() => {
+    const pendingEchoes = pendingEchoesRef.current;
+    const echoIndex = pendingEchoes.indexOf(initialValue);
+    if (echoIndex !== -1) {
+      pendingEchoes.splice(0, echoIndex + 1);
+      return;
+    }
     const editor = editorRef.current;
     if (editor && initialValue !== editor.getValue()) {
+      if (updateTimeoutRef.current) {
+        clearTimeout(updateTimeoutRef.current);
+        updateTimeoutRef.current = null;
+      }
+      pendingEchoes.length = 0;
       const position = editor.getPosition();
       const selections = editor.getSelections();
       editor.setValue(initialValue);
@@ -177,6 +203,10 @@ const SqlEditorInternal = ({
         }
 
         updateTimeoutRef.current = setTimeout(() => {
+          updateTimeoutRef.current = null;
+          const pendingEchoes = pendingEchoesRef.current;
+          pendingEchoes.push(newValue);
+          if (pendingEchoes.length > MAX_PENDING_ECHOES) pendingEchoes.shift();
           onChange(newValue);
         }, 300);
       },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,8 @@
 // Import polyfills first to make Buffer available globally
 import './polyfills';
+// Bundle Monaco locally and register the editor input workarounds before any
+// module calls loader.init().
+import './monacoLoader';
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/src/monacoLoader.ts
+++ b/src/monacoLoader.ts
@@ -1,0 +1,25 @@
+/**
+ * Bundles Monaco with the app instead of letting @monaco-editor/react fetch
+ * it from the jsDelivr CDN at runtime, so the editor works offline and the
+ * shipped version is the one pinned in package.json.
+ *
+ * Must be evaluated before any `loader.init()` call (some modules call it at
+ * import time), hence the side-effect import at the top of main.tsx.
+ */
+import * as monaco from "monaco-editor";
+import { loader } from "@monaco-editor/react";
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+import { installMonacoInputAreaSelectionFix } from "./utils/monacoInputArea";
+
+self.MonacoEnvironment = {
+  getWorker(_workerId: string, label: string): Worker {
+    // SQL and plaintext only need the base editor worker; JSON is the only
+    // language service the app uses (config and MCP editors).
+    return label === "json" ? new JsonWorker() : new EditorWorker();
+  },
+};
+
+loader.config({ monaco });
+
+installMonacoInputAreaSelectionFix();

--- a/src/utils/monacoInputArea.ts
+++ b/src/utils/monacoInputArea.ts
@@ -1,0 +1,67 @@
+/**
+ * Workaround for a Monaco bug in its <textarea>-based keyboard input, the
+ * path used wherever the EditContext API is missing: every WebKit build
+ * (WKWebView on macOS, WebKitGTK on Linux, i.e. Tauri outside Windows) and
+ * Firefox. Chromium is unaffected only because it uses EditContext.
+ *
+ * With `accessibilitySupport: "auto"` Monaco mirrors the text around the
+ * cursor into a hidden textarea. For a backward selection (Shift+Home,
+ * Shift+Left, Shift+Up) it writes the mirror as
+ * `setSelectionRange(anchor, active)` with anchor > active (vscode
+ * `screenReaderUtils.ts`). Browsers collapse a reversed range to the smaller
+ * offset, leaving the textarea caret *before* the selected text. The next typed
+ * character is inserted ahead of the mirrored text, Monaco deduces a
+ * one-character "composition replace", and `cursorTypeEditOperations` ignores
+ * composition input while the editor selection is non-empty, so the character
+ * vanishes (TabularisDB/tabularis#731).
+ *
+ * Collapsing the reversed range at the anchor instead leaves the caret after
+ * the mirrored text. The typed character then lands behind it and Monaco
+ * deduces a plain `type`, which replaces the editor selection as expected.
+ */
+export const MONACO_INPUT_AREA_CLASS = "inputarea";
+
+type SelectionRangeTarget = Pick<HTMLTextAreaElement, "setSelectionRange">;
+
+const installed = new WeakMap<SelectionRangeTarget, () => void>();
+
+/**
+ * Patches `setSelectionRange` on the given prototype so that a reversed range
+ * on Monaco's input textarea collapses at `start` (the selection anchor).
+ * Other textareas keep the native behaviour. Idempotent per prototype; returns
+ * the uninstall function.
+ */
+export function installMonacoInputAreaSelectionFix(
+  prototype: SelectionRangeTarget = HTMLTextAreaElement.prototype,
+): () => void {
+  const existing = installed.get(prototype);
+  if (existing) return existing;
+
+  const native = prototype.setSelectionRange;
+  const patched: HTMLTextAreaElement["setSelectionRange"] = function (
+    this: HTMLTextAreaElement,
+    start,
+    end,
+    direction,
+  ) {
+    const reversed =
+      typeof start === "number" && typeof end === "number" && end < start;
+    const fixedEnd =
+      reversed && this.classList.contains(MONACO_INPUT_AREA_CLASS) ? start : end;
+    if (direction === undefined) {
+      native.call(this, start, fixedEnd);
+    } else {
+      native.call(this, start, fixedEnd, direction);
+    }
+  };
+  prototype.setSelectionRange = patched;
+
+  const uninstall = () => {
+    if (prototype.setSelectionRange === patched) {
+      prototype.setSelectionRange = native;
+    }
+    installed.delete(prototype);
+  };
+  installed.set(prototype, uninstall);
+  return uninstall;
+}

--- a/tests/components/ui/SqlEditorWrapper.test.tsx
+++ b/tests/components/ui/SqlEditorWrapper.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { SqlEditorWrapper } from '../../../src/components/ui/SqlEditorWrapper';
 import { SettingsContext, DEFAULT_SETTINGS } from '../../../src/contexts/SettingsContext';
 import { CommandPaletteDispatchContext } from '../../../src/contexts/CommandPaletteContext';
@@ -536,5 +536,120 @@ describe('SqlEditorWrapper', () => {
         'smart'
       );
     });
+  });
+});
+
+describe('SqlEditorWrapper debounced value sync', () => {
+  const mockOnChange = vi.fn();
+  const mockOnRun = vi.fn();
+
+  const mountValueEditor = (initial: string) => {
+    let value = initial;
+    const editor = {
+      addAction: vi.fn(),
+      addCommand: vi.fn(),
+      dispose: vi.fn(),
+      getContribution: vi.fn(() => null),
+      getModel: vi.fn(() => null),
+      onKeyDown: vi.fn(),
+      trigger: vi.fn(),
+      getValue: vi.fn(() => value),
+      setValue: vi.fn((next: string) => {
+        value = next;
+      }),
+      getPosition: vi.fn(() => ({ lineNumber: 1, column: 2 })),
+      setPosition: vi.fn(),
+      getSelections: vi.fn(() => []),
+      setSelections: vi.fn(),
+    };
+    monacoRenderState.onMount?.(editor, {
+      KeyMod: { CtrlCmd: 1, Shift: 2, Alt: 4 },
+      KeyCode: { KeyX: 8, KeyC: 16, KeyV: 32, Enter: 64, KeyF: 128, KeyA: 256 },
+    });
+    // Simulates the user typing: Monaco already holds the new text when it
+    // notifies onChange.
+    const type = (next: string) => {
+      value = next;
+      fireEvent.change(screen.getByTestId('monaco-editor'), { target: { value: next } });
+    };
+    return { editor, type };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    monacoRenderState.onMount = undefined;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const renderEditor = (initialValue: string) =>
+    render(
+      <SqlEditorWrapper initialValue={initialValue} onChange={mockOnChange} onRun={mockOnRun} />,
+      { wrapper: standaloneWrapper },
+    );
+
+  it('does not overwrite keystrokes typed while a debounced change is echoed back', () => {
+    const { rerender } = renderEditor('');
+    const { editor, type } = mountValueEditor('');
+
+    type('x');
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(mockOnChange).toHaveBeenCalledWith('x');
+
+    // The consumer re-renders with "x" only after the user already typed "y".
+    type('xy');
+    rerender(
+      <SqlEditorWrapper initialValue="x" onChange={mockOnChange} onRun={mockOnRun} />,
+    );
+
+    expect(editor.setValue).not.toHaveBeenCalled();
+    expect(editor.getValue()).toBe('xy');
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(mockOnChange).toHaveBeenLastCalledWith('xy');
+    rerender(
+      <SqlEditorWrapper initialValue="xy" onChange={mockOnChange} onRun={mockOnRun} />,
+    );
+    expect(editor.setValue).not.toHaveBeenCalled();
+  });
+
+  it('applies an external initialValue change and restores the cursor', () => {
+    const { rerender } = renderEditor('');
+    const { editor, type } = mountValueEditor('');
+
+    type('x');
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    rerender(
+      <SqlEditorWrapper initialValue="SELECT 1" onChange={mockOnChange} onRun={mockOnRun} />,
+    );
+
+    expect(editor.setValue).toHaveBeenCalledWith('SELECT 1');
+    expect(editor.setPosition).toHaveBeenCalledWith({ lineNumber: 1, column: 2 });
+  });
+
+  it('lets an external change win over a pending debounced flush', () => {
+    const { rerender } = renderEditor('');
+    const { editor, type } = mountValueEditor('');
+
+    type('ab');
+    rerender(
+      <SqlEditorWrapper initialValue="SELECT 1" onChange={mockOnChange} onRun={mockOnRun} />,
+    );
+    expect(editor.setValue).toHaveBeenCalledWith('SELECT 1');
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(mockOnChange).not.toHaveBeenCalledWith('ab');
   });
 });

--- a/tests/utils/monacoInputArea.test.ts
+++ b/tests/utils/monacoInputArea.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  MONACO_INPUT_AREA_CLASS,
+  installMonacoInputAreaSelectionFix,
+} from "../../src/utils/monacoInputArea";
+
+function createTextarea(className = ""): HTMLTextAreaElement {
+  const textarea = document.createElement("textarea");
+  textarea.className = className;
+  textarea.value = "SELECT";
+  return textarea;
+}
+
+describe("monacoInputArea", () => {
+  describe("installMonacoInputAreaSelectionFix", () => {
+    let uninstall: (() => void) | undefined;
+
+    afterEach(() => {
+      uninstall?.();
+      uninstall = undefined;
+    });
+
+    it("collapses a reversed range at the anchor on Monaco's input textarea", () => {
+      uninstall = installMonacoInputAreaSelectionFix();
+      const textarea = createTextarea(MONACO_INPUT_AREA_CLASS);
+
+      // Monaco writes a backward selection (Shift+Home over "SELECT") as (6, 0).
+      textarea.setSelectionRange(6, 0);
+
+      expect([textarea.selectionStart, textarea.selectionEnd]).toEqual([6, 6]);
+    });
+
+    it("keeps forward ranges and the direction argument untouched", () => {
+      uninstall = installMonacoInputAreaSelectionFix();
+      const textarea = createTextarea(MONACO_INPUT_AREA_CLASS);
+
+      textarea.setSelectionRange(1, 4, "backward");
+
+      expect([textarea.selectionStart, textarea.selectionEnd]).toEqual([1, 4]);
+      expect(textarea.selectionDirection).toBe("backward");
+    });
+
+    it("forwards calls from other textareas to the native method unchanged", () => {
+      const native = vi.fn();
+      const prototype = { setSelectionRange: native };
+      uninstall = installMonacoInputAreaSelectionFix(prototype);
+      const plain = createTextarea("some-other-field");
+
+      prototype.setSelectionRange.call(plain, 6, 0);
+      prototype.setSelectionRange.call(plain, 6, 0, "none");
+
+      expect(native).toHaveBeenNthCalledWith(1, 6, 0);
+      expect(native).toHaveBeenNthCalledWith(2, 6, 0, "none");
+    });
+
+    it("passes null offsets through without touching them", () => {
+      const native = vi.fn();
+      const prototype = { setSelectionRange: native };
+      uninstall = installMonacoInputAreaSelectionFix(prototype);
+      const textarea = createTextarea(MONACO_INPUT_AREA_CLASS);
+
+      prototype.setSelectionRange.call(textarea, null, null);
+
+      expect(native).toHaveBeenCalledWith(null, null);
+    });
+
+    it("is idempotent and restores the native method on uninstall", () => {
+      const native = HTMLTextAreaElement.prototype.setSelectionRange;
+
+      const first = installMonacoInputAreaSelectionFix();
+      const second = installMonacoInputAreaSelectionFix();
+      expect(second).toBe(first);
+      expect(HTMLTextAreaElement.prototype.setSelectionRange).not.toBe(native);
+
+      first();
+      expect(HTMLTextAreaElement.prototype.setSelectionRange).toBe(native);
+
+      // A fresh install after uninstall patches again.
+      uninstall = installMonacoInputAreaSelectionFix();
+      expect(HTMLTextAreaElement.prototype.setSelectionRange).not.toBe(native);
+    });
+  });
+});


### PR DESCRIPTION
Closes #731 (originally TabularisDB/tabularis-postgresql-plugin#64).

Two independent bugs made the SQL console swallow typed characters. Both are fixed here.

## What changed

**1. Backward selection replaced by typing (WebKit only)**

Monaco falls back to a hidden textarea for keyboard input wherever the EditContext API is missing, which is every WebKit build (WebKitGTK on Linux, WKWebView on macOS) and Firefox. For a backward selection (Shift+Home, Shift+Left, Shift+Up) it mirrors the selection into that textarea as `setSelectionRange(anchor, active)` with anchor > active. Browsers collapse such a reversed range to the smaller offset, so the next typed character lands before the mirrored text, Monaco deduces a one-character composition over a non-empty selection and discards it. Chromium is unaffected only because it uses EditContext, which is why this never showed on Windows.

`installMonacoInputAreaSelectionFix` (src/utils/monacoInputArea.ts) collapses the reversed range at the anchor for Monaco's `.inputarea` textarea only. Monaco 0.56.0 and current VS Code main still carry the same code, so this stays app-side for now.

**2. Debounced query flush dropping keystrokes (all platforms)**

`SqlEditorWrapper` debounces `onChange` by 300ms and re-syncs Monaco from `initialValue` whenever the prop differs from the editor. The flush re-renders the page asynchronously, so a keystroke typed between the flush and that effect was already in the editor but not yet in `initialValue`, and the effect wrote the stale value back with `setValue`. Typing at roughly the debounce interval lost every third character (`abcd` typed at 0.30 to 0.32s intervals came out as `abd`).

The wrapper now remembers the values it handed to `onChange` until the consumer echoes them back and never re-applies an echo. A genuinely external `initialValue` change (for example a saved query loaded into the tab) still wins and cancels any pending flush.

**3. Monaco bundled locally**

`@monaco-editor/react` was fetching Monaco from the jsDelivr CDN at runtime, while a full copy was already in the bundle and unused. `src/monacoLoader.ts` now points the loader at the bundled package and registers the editor and JSON workers through `MonacoEnvironment`, so the editor works offline and ships the version pinned in package.json.

## Verification

- Reproduced both bugs and confirmed the fixes in the real Tauri dev app on WebKitGTK 2.52.6, driving the console with xdotool and reading the editor state through the WebKit remote inspector: P, Shift+Home, X, Y gives `XY`; a, b, c, d at 0.29 to 0.33s intervals gives `abcd` every time; multi-line Shift+Up replacement works; forward selections and Ctrl+A unchanged.
- Minimal Monaco page on WebKitGTK, Firefox and Chromium for the selection bug (Chromium clean via EditContext, the other two broken before the fix).
- New unit tests: `tests/utils/monacoInputArea.test.ts` and three cases in `tests/components/ui/SqlEditorWrapper.test.tsx` (two of them fail against the previous wrapper).
- Full vitest suite, `tsc -b`, eslint and `vite build` pass. No jsDelivr request at runtime.
