### PR TITLE
fix: address 2 Kilo review follow-ups from PR #685

### DIFF
--- a/src-tauri/src/plugins/force_install.rs
+++ b/src-tauri/src/plugins/force_install.rs
@@ -128,7 +128,19 @@ fn persist_activation(app: &AppHandle, plugin_id: &str) -> Result<(), String> {
     if updated.active_external_drivers == config.active_external_drivers {
         return Ok(());
     }
-    config::save_config(app.clone(), updated)
+    // Pass save_config a config with only `active_external_drivers` set,
+    // not the full `updated` snapshot: save_config re-reads disk and
+    // overwrites every `Some` field, so writing back the stale snapshot
+    // taken above would silently revert any other setting the user changed
+    // in the meantime — the inverse of the race the frontend's
+    // `plugin-activated` listener already guards against.
+    config::save_config(
+        app.clone(),
+        AppConfig {
+            active_external_drivers: updated.active_external_drivers,
+            ..AppConfig::default()
+        },
+    )
 }
 
 /// Pure helper: return a copy of `config` with `plugin_id` added to

--- a/src/components/modals/MigrationChecklistModal.tsx
+++ b/src/components/modals/MigrationChecklistModal.tsx
@@ -121,6 +121,20 @@ export const MigrationChecklistModal = ({
     };
   }, []);
 
+  // Escape closes the modal, same as the X button — per .rules/modals.md #4.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setRowStatus({});
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   const toggleChecked = (id: string) => {

--- a/tests/components/modals/MigrationChecklistModal.test.tsx
+++ b/tests/components/modals/MigrationChecklistModal.test.tsx
@@ -72,6 +72,24 @@ describe("MigrationChecklistModal", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it("closes on Escape, same as the X button", () => {
+    render(
+      <MigrationChecklistModal
+        isOpen
+        onClose={onClose}
+        connections={[]}
+        manifest={undefined}
+        repoUrl={undefined}
+        pluginVersion="1.0.0"
+        migrateConnection={migrateConnection}
+      />,
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   describe("mounts fresh with whatever data it's given", () => {
     // Connections.tsx conditionally mounts this component
     // ({isMigrationChecklistOpen && <MigrationChecklistModal ... />}), so


### PR DESCRIPTION
## Summary

Two items the Kilo bot [flagged on #685](https://github.com/TabularisDB/tabularis/pull/685#pullrequestreview-5156439992) ("Address before merge") that didn't get resolved before it merged. Split out here since that branch is now fully absorbed into `main`.

- **WARNING** — `src-tauri/src/plugins/force_install.rs`: `persist_activation` snapshotted the full on-disk config, then handed that stale snapshot to `save_config`. `save_config` re-reads disk and overwrites every `Some` field, so any setting the user changed elsewhere in that read-write window (e.g. theme, language) got silently reverted — the inverse of the race the frontend's `plugin-activated` listener already guards against. Now it passes `save_config` a config with only `active_external_drivers` set, so no other field can ever be touched by this write.
- **SUGGESTION** — `src/components/modals/MigrationChecklistModal.tsx`: missing Escape-to-close, required by `.rules/modals.md` #4 and present on every sibling dismissible modal. Added, following `TabSwitcherModal`'s pattern, plus a regression test. The Escape handler isn't gated on `migrating` — intentional, it matches the existing X button, which was already unguarded.

## Test plan

- [x] `cargo test --lib force_install` — all pass
- [x] `pnpm vitest run tests/components/modals/MigrationChecklistModal.test.tsx` — 20/20 pass (including new Escape test)
- [x] `pnpm lint`, `cargo fmt --check`, `cargo clippy --lib` — no new warnings
- [x] GitNexus `detect_changes` — low risk, touches only the two intended symbols

**Note on the config-race fix:** there's no test that reproduces the actual race — it's a microsecond TOCTOU window, and this repo has no `AppHandle` mocking to build a deterministic integration test around it. Confidence rests on static reasoning instead: `save_config` only overwrites fields that are `Some`, and `AppConfig::default()` guarantees every field but `active_external_drivers` is `None` in what we now send it, so the invariant holds by construction rather than by timing.