### PR TITLE
feat(settings): add a font setting for query result cells

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -83,6 +83,8 @@ pub struct AppConfig {
     pub release_channel: Option<String>,
     pub plugins: Option<HashMap<String, PluginConfig>>,
     pub editor_theme: Option<String>,
+    /// Font for query result cells ("inherit" follows the interface font). Default: JetBrains Mono.
+    pub result_font_family: Option<String>,
     pub editor_font_family: Option<String>,
     pub editor_font_size: Option<u32>,
     pub editor_line_height: Option<f32>,
@@ -433,6 +435,9 @@ pub fn save_config(app: AppHandle, config: AppConfig) -> Result<(), String> {
         }
         if config.editor_theme.is_some() {
             existing_config.editor_theme = config.editor_theme;
+        }
+        if config.result_font_family.is_some() {
+            existing_config.result_font_family = config.result_font_family;
         }
         if config.editor_font_family.is_some() {
             existing_config.editor_font_family = config.editor_font_family;
@@ -1064,6 +1069,7 @@ mod tests {
         let config = AppConfig::default();
         assert!(config.safety_confirmation_delay_enabled.is_none());
         assert!(config.editor_theme.is_none());
+        assert!(config.result_font_family.is_none());
         assert!(config.editor_font_family.is_none());
         assert!(config.editor_font_size.is_none());
         assert!(config.editor_line_height.is_none());
@@ -1077,6 +1083,7 @@ mod tests {
     fn editor_fields_serialize_with_camel_case() {
         let mut config = AppConfig::default();
         config.editor_font_family = Some("JetBrains Mono".to_string());
+        config.result_font_family = Some("inherit".to_string());
         config.editor_font_size = Some(16);
         config.editor_line_height = Some(1.5);
         config.editor_tab_size = Some(4);
@@ -1088,6 +1095,7 @@ mod tests {
 
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("editorFontFamily"));
+        assert!(json.contains("resultFontFamily"));
         assert!(json.contains("editorFontSize"));
         assert!(json.contains("editorLineHeight"));
         assert!(json.contains("editorTabSize"));
@@ -1098,6 +1106,7 @@ mod tests {
         assert!(json.contains("safetyConfirmationDelayEnabled"));
         // snake_case must not appear
         assert!(!json.contains("editor_font_family"));
+        assert!(!json.contains("result_font_family"));
         assert!(!json.contains("editor_accept_suggestion_on_enter"));
         assert!(!json.contains("safety_confirmation_delay_enabled"));
     }
@@ -1106,6 +1115,7 @@ mod tests {
     fn editor_fields_round_trip() {
         let json = r#"{
             "editorFontFamily": "Hack",
+            "resultFontFamily": "Open Sans",
             "editorFontSize": 14,
             "editorLineHeight": 1.8,
             "editorTabSize": 2,
@@ -1118,6 +1128,7 @@ mod tests {
 
         let config: AppConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.editor_font_family.as_deref(), Some("Hack"));
+        assert_eq!(config.result_font_family.as_deref(), Some("Open Sans"));
         assert_eq!(config.editor_font_size, Some(14));
         assert_eq!(config.editor_tab_size, Some(2));
         assert_eq!(config.editor_word_wrap, Some(true));

--- a/src/components/settings/AppearanceTab.tsx
+++ b/src/components/settings/AppearanceTab.tsx
@@ -4,7 +4,11 @@ import { Monitor, Code2 } from "lucide-react";
 import clsx from "clsx";
 import { useSettings } from "../../hooks/useSettings";
 import { useTheme } from "../../hooks/useTheme";
-import { getFontCSS } from "../../utils/settings";
+import {
+  DEFAULT_RESULT_FONT_FAMILY,
+  RESULT_FONT_INHERIT,
+  getFontCSS,
+} from "../../utils/settings";
 import {
   SettingSection,
   SettingRow,
@@ -170,6 +174,25 @@ export function AppearanceTab() {
                 onChange={(v) => updateSetting("stickyColumnHeaders", v)}
               />
             </SettingRow>
+            <div className="py-3">
+              <p className="text-sm text-primary">
+                {t("settings.dataGrid.fontFamily")}
+              </p>
+              <p className="text-xs text-muted mb-3">
+                {t("settings.dataGrid.fontFamilyDesc")}
+              </p>
+              <FontPicker
+                value={settings.resultFontFamily ?? DEFAULT_RESULT_FONT_FAMILY}
+                onChange={(f) => updateSetting("resultFontFamily", f)}
+                getPreviewCSS={getFontCSS}
+                inputId="custom-result-font-input"
+                inheritOption={{
+                  value: RESULT_FONT_INHERIT,
+                  label: t("settings.dataGrid.fontSameAsInterface"),
+                  previewCSS: "var(--font-base)",
+                }}
+              />
+            </div>
           </SettingSection>
 
           <ResultColorsSection />

--- a/src/components/settings/FontPicker.tsx
+++ b/src/components/settings/FontPicker.tsx
@@ -9,6 +9,11 @@ interface FontPickerProps {
   onChange: (font: string) => void;
   getPreviewCSS: (fontName: string) => string;
   inputId: string;
+  /**
+   * Optional extra tile rendered before the bundled fonts, e.g. a
+   * "Same as interface" choice. `value` is what gets stored on selection.
+   */
+  inheritOption?: { value: string; label: string; previewCSS: string };
 }
 
 export function FontPicker({
@@ -16,15 +21,44 @@ export function FontPicker({
   onChange,
   getPreviewCSS,
   inputId,
+  inheritOption,
 }: FontPickerProps) {
   const { t } = useTranslation();
-  const isPreset = AVAILABLE_FONTS.some((f) => f.name === value);
+  const isPreset =
+    AVAILABLE_FONTS.some((f) => f.name === value) ||
+    (inheritOption !== undefined && value === inheritOption.value);
   const [customFont, setCustomFont] = useState(() =>
     !isPreset && value ? value : "",
   );
 
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+      {inheritOption && (
+        <button
+          onClick={() => onChange(inheritOption.value)}
+          className={clsx(
+            "p-3 rounded-xl border transition-all text-left",
+            value === inheritOption.value
+              ? "bg-surface-secondary border-blue-500 shadow-lg shadow-blue-900/20"
+              : "bg-base border-default hover:border-strong",
+          )}
+        >
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm font-medium text-primary">
+              {inheritOption.label}
+            </span>
+            {value === inheritOption.value && (
+              <CheckCircle2 size={16} className="text-blue-500" />
+            )}
+          </div>
+          <p
+            className="text-xs text-muted truncate"
+            style={{ fontFamily: inheritOption.previewCSS }}
+          >
+            Aa Bb Cc 123
+          </p>
+        </button>
+      )}
       {AVAILABLE_FONTS.map((font) => (
         <button
           key={font.name}

--- a/src/components/ui/DataGridRow.tsx
+++ b/src/components/ui/DataGridRow.tsx
@@ -25,6 +25,7 @@ import { isLongTextCellTarget, truncateCellPreview } from "../../utils/text";
 import { getForeignKeyForPreview } from "../../utils/foreignKeys";
 import { getDateInputMode } from "../../utils/dateInput";
 import { renderDefaultCellContent } from "../../utils/dataGridCell";
+import { resolveResultFontFamily } from "../../utils/settings";
 import { GeometryInput } from "./GeometryInput";
 import { DateInput } from "./DateInput";
 import { JsonCell } from "./JsonCell";
@@ -432,7 +433,7 @@ export const MemoRow = React.memo(function MemoRow(rowCtx: MemoRowProps) {
               onContextMenu={(e) =>
                 handleContextMenu(e, rowOriginal, rowIndex, colIndex, colName)
               }
-              className={`px-4 py-1.5 text-sm border-b border-r border-default last:border-r-0 font-mono ${isEditing ? "relative" : "whitespace-nowrap truncate max-w-[300px]"} ${fkForPreview ? "cursor-pointer" : "cursor-text"} ${stateClass} ${selectedColIndices.has(colIndex) || (rangeColBounds !== null && colIndex >= rangeColBounds.minCol && colIndex <= rangeColBounds.maxCol) ? "bg-blue-500/15" : ""} ${isFocused ? "ring-2 ring-inset ring-blue-400" : ""}`}
+              className={`px-4 py-1.5 text-sm border-b border-r border-default last:border-r-0 font-result ${isEditing ? "relative" : "whitespace-nowrap truncate max-w-[300px]"} ${fkForPreview ? "cursor-pointer" : "cursor-text"} ${stateClass} ${selectedColIndices.has(colIndex) || (rangeColBounds !== null && colIndex >= rangeColBounds.minCol && colIndex <= rangeColBounds.maxCol) ? "bg-blue-500/15" : ""} ${isFocused ? "ring-2 ring-inset ring-blue-400" : ""}`}
               title={
                 // The hover tooltip would leak the real value of a masked cell.
                 !isEditing && !isMasked
@@ -485,7 +486,7 @@ export const MemoRow = React.memo(function MemoRow(rowCtx: MemoRowProps) {
                             // Open sidebar with the current row
                             openInSidebar(rowIndex, colName);
                           }}
-                          className="w-full bg-base text-primary border-none outline-none p-0 m-0 font-mono"
+                          className="w-full bg-base text-primary border-none outline-none p-0 m-0 font-result"
                         />
                       );
                     }
@@ -552,8 +553,10 @@ export const MemoRow = React.memo(function MemoRow(rowCtx: MemoRowProps) {
                     const canvas = document.createElement("canvas");
                     const ctx = canvas.getContext("2d");
                     if (ctx) {
-                      ctx.font =
-                        "14px ui-monospace, SFMono-Regular, monospace";
+                      // Measure with the same font the textarea renders in
+                      // (the "Result font" setting), otherwise a proportional
+                      // font would be sized with monospace metrics.
+                      ctx.font = `14px ${resolveResultFontFamily()}`;
                     }
                     const longestLineWidth = ctx
                       ? Math.max(
@@ -597,7 +600,7 @@ export const MemoRow = React.memo(function MemoRow(rowCtx: MemoRowProps) {
                           }}
                           onBlur={handleEditCommit}
                           onKeyDown={handleKeyDown}
-                          className="absolute left-0 top-0 max-w-[400px] max-h-[120px] bg-base text-primary border border-blue-500 rounded shadow-lg p-2 font-mono text-sm resize-none z-50 outline-none"
+                          className="absolute left-0 top-0 max-w-[400px] max-h-[120px] bg-base text-primary border border-blue-500 rounded shadow-lg p-2 font-result text-sm resize-none z-50 outline-none"
                         />
                       </>
                     );

--- a/src/contexts/SettingsContext.ts
+++ b/src/contexts/SettingsContext.ts
@@ -54,6 +54,8 @@ export interface Settings {
   resultTypeColors?: Record<string, string>;
   /** Keep the result grid's column headers pinned to the top while scrolling. Default: true. */
   stickyColumnHeaders?: boolean;
+  /** Font used for query result cells. A font name from AVAILABLE_FONTS, a custom family, or RESULT_FONT_INHERIT to follow the interface font. Default: "JetBrains Mono". */
+  resultFontFamily?: string;
   aiEnabled: boolean;
   aiProvider: AiProvider | null;
   aiModel: string | null;
@@ -203,6 +205,7 @@ export const DEFAULT_SETTINGS: Settings = {
   resultColorByType: false,
   resultTypeColors: {},
   stickyColumnHeaders: true,
+  resultFontFamily: "JetBrains Mono",
   aiEnabled: false,
   aiProvider: null,
   aiModel: null,

--- a/src/contexts/SettingsProvider.tsx
+++ b/src/contexts/SettingsProvider.tsx
@@ -7,7 +7,11 @@ import {
   DEFAULT_SETTINGS,
   type Settings,
 } from "./SettingsContext";
-import { getFontCSS, stripSessionFields } from "../utils/settings";
+import {
+  applyResultFontToDocument,
+  getFontCSS,
+  stripSessionFields,
+} from "../utils/settings";
 
 const LANGUAGE_APPLICATION_TIMEOUT_MS = 3000;
 
@@ -240,6 +244,7 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
         );
         document.body.style.fontFamily = fontFamily;
         document.body.style.fontSize = `${fontSize}px`;
+        applyResultFontToDocument(finalSettings.resultFontFamily);
 
         const languageAlreadyApplied = isLanguageApplied(finalSettings.language);
         if (languageAlreadyApplied) {
@@ -375,6 +380,11 @@ export const SettingsProvider = ({ children }: { children: ReactNode }) => {
       console.warn("Failed to cache font settings:", e);
     }
   }, [settings.fontFamily, settings.fontSize]);
+
+  // Apply query result font
+  useEffect(() => {
+    applyResultFontToDocument(settings.resultFontFamily);
+  }, [settings.resultFontFamily]);
 
   // Apply font size
   useEffect(() => {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -497,7 +497,10 @@
     "dataGrid": {
       "title": "Data Grid",
       "stickyHeaders": "Sticky column headers",
-      "stickyHeadersDesc": "Keep the column headers visible at the top while scrolling through results."
+      "stickyHeadersDesc": "Keep the column headers visible at the top while scrolling through results.",
+      "fontFamily": "Result font",
+      "fontFamilyDesc": "Font used for query result cells. Monospace keeps values aligned; pick \"Same as interface\" to reuse the application font.",
+      "fontSameAsInterface": "Same as interface"
     },
     "appearance_general": "General",
     "appearance_sqlEditor": "SQL Editor",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -489,6 +489,14 @@
     "fontSizeDesc": "Regola la dimensione base del font usata nell'applicazione (10-20px).",
     "preview": "Anteprima",
     "fontPreviewText": "La volpe marrone salta sopra il cane pigro",
+    "dataGrid": {
+      "title": "Griglia dati",
+      "stickyHeaders": "Intestazioni colonne fisse",
+      "stickyHeadersDesc": "Mantieni le intestazioni delle colonne visibili in alto mentre scorri i risultati.",
+      "fontFamily": "Font dei risultati",
+      "fontFamilyDesc": "Font usato nelle celle dei risultati delle query. Il monospaziato mantiene i valori allineati; scegli \"Come interfaccia\" per riutilizzare il font dell'applicazione.",
+      "fontSameAsInterface": "Come interfaccia"
+    },
     "appearance_general": "Generali",
     "appearance_sqlEditor": "Editor SQL",
     "appearance_editorTheme": "Tema dell'Editor",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -468,7 +468,10 @@
     "dataGrid": {
       "title": "Grade de Dados",
       "stickyHeaders": "Cabeçalhos de coluna fixos",
-      "stickyHeadersDesc": "Mantém os cabeçalhos das colunas visíveis no topo ao rolar pelos resultados."
+      "stickyHeadersDesc": "Mantém os cabeçalhos das colunas visíveis no topo ao rolar pelos resultados.",
+      "fontFamily": "Fonte dos resultados",
+      "fontFamilyDesc": "Fonte usada nas células dos resultados de consulta. Monoespaçada mantém os valores alinhados; escolha \"Igual à interface\" para reutilizar a fonte do aplicativo.",
+      "fontSameAsInterface": "Igual à interface"
     },
     "appearance_general": "Geral",
     "appearance_sqlEditor": "Editor SQL",

--- a/src/index.css
+++ b/src/index.css
@@ -79,6 +79,7 @@
   --font-base: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   --font-size-base: 14px;
   --font-mono: "JetBrains Mono", "Consolas", "Courier New", monospace;
+  --font-result: var(--font-mono);
 
   /* Apply immediately */
   font-family: var(--font-base);
@@ -254,9 +255,12 @@ code {
   .bg-accent-info { background-color: var(--accent-info); }
   
   .font-mono-theme { font-family: var(--font-mono); }
+  /* Query result cells: follows the "Result font" setting */
+  .font-result { font-family: var(--font-result); }
   
   /* Fix for font-mono + truncate on Windows */
-  .font-mono.truncate {
+  .font-mono.truncate,
+  .font-result.truncate {
     min-width: 0;
   }
   

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -38,6 +38,49 @@ export function getFontCSS(fontFamily: string): string {
   return FONT_MAP[fontFamily] || fontFamily || FONT_MAP["System"];
 }
 
+/** Sentinel value for `resultFontFamily`: result cells follow the interface font. */
+export const RESULT_FONT_INHERIT = "inherit";
+export const DEFAULT_RESULT_FONT_FAMILY = "JetBrains Mono";
+
+/**
+ * Resolve the CSS font-family for query result cells. `RESULT_FONT_INHERIT`
+ * maps to the interface font variable so the grid tracks the UI font setting.
+ */
+export function getResultFontCSS(resultFontFamily: string | undefined): string {
+  if (!resultFontFamily) return getFontCSS(DEFAULT_RESULT_FONT_FAMILY);
+  if (resultFontFamily === RESULT_FONT_INHERIT) return "var(--font-base)";
+  return getFontCSS(resultFontFamily);
+}
+
+/**
+ * Resolve the font-family the result grid actually renders with. Reads the
+ * computed style of a probe element so `var()` chains (e.g. RESULT_FONT_INHERIT
+ * pointing at `--font-base`) are fully resolved; usable as a canvas `ctx.font`.
+ */
+export function resolveResultFontFamily(): string {
+  if (typeof document === "undefined" || !document.body) {
+    return getResultFontCSS(undefined);
+  }
+  const probe = document.createElement("span");
+  probe.className = "font-result";
+  probe.style.position = "absolute";
+  probe.style.visibility = "hidden";
+  document.body.appendChild(probe);
+  const family = getComputedStyle(probe).fontFamily;
+  probe.remove();
+  return family || getResultFontCSS(undefined);
+}
+
+export function applyResultFontToDocument(
+  resultFontFamily: string | undefined,
+): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.style.setProperty(
+    "--font-result",
+    getResultFontCSS(resultFontFamily),
+  );
+}
+
 export function createFontCSSVariables(
   fontFamily: string,
   fontSize: number,

--- a/tests/utils/settings.test.ts
+++ b/tests/utils/settings.test.ts
@@ -17,6 +17,10 @@ import {
   detectAIProviderFromKeys,
   shouldDetectAIProvider,
   applyFontToDocument,
+  getResultFontCSS,
+  applyResultFontToDocument,
+  RESULT_FONT_INHERIT,
+  DEFAULT_RESULT_FONT_FAMILY,
   getLanguageForI18n,
   stripSessionFields,
   type FontCache,
@@ -419,6 +423,39 @@ describe('settings', () => {
     });
   });
 
+  describe('getResultFontCSS', () => {
+    it('should default to the bundled monospace font when unset', () => {
+      expect(getResultFontCSS(undefined)).toBe(FONT_MAP[DEFAULT_RESULT_FONT_FAMILY]);
+      expect(getResultFontCSS('')).toBe(FONT_MAP[DEFAULT_RESULT_FONT_FAMILY]);
+    });
+
+    it('should follow the interface font for the inherit sentinel', () => {
+      expect(getResultFontCSS(RESULT_FONT_INHERIT)).toBe('var(--font-base)');
+    });
+
+    it('should map bundled fonts through FONT_MAP', () => {
+      expect(getResultFontCSS('Hack')).toBe(FONT_MAP['Hack']);
+    });
+
+    it('should pass custom fonts through as-is', () => {
+      expect(getResultFontCSS('Comic Sans MS')).toBe('Comic Sans MS');
+    });
+  });
+
+  describe('applyResultFontToDocument', () => {
+    it('should set the --font-result CSS variable', () => {
+      const setProperty = vi.fn();
+      Object.defineProperty(document, 'documentElement', {
+        value: { style: { setProperty } },
+        writable: true,
+      });
+
+      applyResultFontToDocument(RESULT_FONT_INHERIT);
+
+      expect(setProperty).toHaveBeenCalledWith('--font-result', 'var(--font-base)');
+    });
+  });
+
   describe('applyFontToDocument', () => {
     beforeEach(() => {
       // Mock document
@@ -600,6 +637,10 @@ describe('getLanguageForI18n', () => {
 
     it('should not set an editor theme override by default', () => {
       expect(DEFAULT_SETTINGS.editorTheme).toBeUndefined();
+    });
+
+    it('should default the result font to JetBrains Mono', () => {
+      expect(DEFAULT_SETTINGS.resultFontFamily).toBe(DEFAULT_RESULT_FONT_FAMILY);
     });
   });
 


### PR DESCRIPTION
Closes #726

## What

Adds a **Result font** picker under Settings > Appearance > Data Grid. Query result cells can now use:

- **Same as interface**: follows the UI font setting (the request in #726)
- any bundled font (JetBrains Mono, Hack, DejaVu Sans Mono, Open Sans, Roboto, ...)
- a custom font family

Default is unchanged: JetBrains Mono.

## How

- New `resultFontFamily` setting (frontend `Settings` + Rust `AppConfig.result_font_family`, same merge semantics as `editor_font_family`).
- New `--font-result` CSS variable, defaulting to `var(--font-mono)`. "Same as interface" is stored as `inherit` and maps to `var(--font-base)`, so it tracks later UI font changes automatically.
- `DataGridRow` cells, the inline edit input and the multiline textarea switch from the hardcoded Tailwind `font-mono` class to a `font-result` class. The Windows truncate fix is extended to the new class.
- The textarea width measurement resolves the actual computed result font instead of a hardcoded monospace stack, so a proportional font is no longer sized with monospace metrics.
- `FontPicker` gains an optional `inheritOption` tile; the interface and editor pickers are untouched.
- Other `font-mono` usages (logs, hex, JSON, SQL previews, errors) are intentionally left alone: monospace is functional there.

## Translations

en, it, pt-BR. Other locales fall back to English.

## Tests

- `tests/utils/settings.test.ts`: `getResultFontCSS`, `applyResultFontToDocument`, default value.
- `src-tauri/src/config.rs`: default, camelCase serialization and round trip for `resultFontFamily`.
- Full `pnpm test` (4068 tests) and `cargo test config::` pass; `tsc` and `eslint` clean.

## Manual check

1. Settings > Appearance > Data Grid > Result font: pick "Same as interface", then change the interface font. Grid cells follow it.
2. Pick "Open Sans", double-click a multiline cell: the textarea is sized correctly for the proportional font.
3. Restart the app: the choice persists (`resultFontFamily` in the config file).
