### PR TITLE
feat(plugins): discover capabilities and types per connection

### DIFF
--- a/plugins/CONNECTION_METADATA.md
+++ b/plugins/CONNECTION_METADATA.md
@@ -1,0 +1,218 @@
+# Connection metadata discovery
+
+Generic database plugins can opt in to `get_connection_metadata` to report the
+capabilities and data types of each connection. Plugins that do not opt in keep
+the static manifest behavior and receive no discovery requests.
+
+The motivating example is [tabularis-jdbc](https://github.com/tabularis-jdbc/tabularis-jdbc),
+discussed in [#728](https://github.com/orgs/TabularisDB/discussions/728).
+Its launcher selects JDBC dependencies from a URL. The database behind that URL
+can report its own schemas, identifier quoting and types through JDBC metadata.
+Those values should not have to be copied into a separate manifest for every
+engine, or shared between unrelated connections.
+
+## Opting in
+
+Add `connection_metadata: true` at the manifest root. Keep the connection form
+and conservative fallback values in the manifest. An empty static `data_types`
+list is valid.
+
+For a generic JDBC plugin, the relevant fields could be:
+
+```json
+{
+  "name": "jdbc",
+  "version": "0.1.0",
+  "description": "Generic JDBC driver",
+  "executable": "tabularis-jdbc",
+  "connection_metadata": true,
+  "capabilities": {
+    "connection_string": true,
+    "connection_uri": true,
+    "connection_uri_schemes": ["jdbc"],
+    "connection_string_example": "jdbc:postgresql://localhost:5432/example",
+    "file_based": false,
+    "schemas": false,
+    "views": false,
+    "routines": false,
+    "identifier_quote": "\"",
+    "sql_dialect": "generic",
+    "alter_primary_key": false,
+    "alter_column": false,
+    "create_foreign_keys": false,
+    "manage_tables": false
+  },
+  "data_types": []
+}
+```
+
+Older hosts ignore the opt-in and use the static values. A plugin that cannot
+work with those values must set `min_runtime_version` to the first released
+Tabularis version containing this feature before publishing.
+
+Tabularium maintains its own registry schema. Its driver-kind extensions must
+also allow the optional boolean `connection_metadata` field before a manifest
+using it can pass strict registry validation. This host change does not modify
+the deployed registry configuration.
+
+## Request and response
+
+Discovery is connection-scoped. It is not part of `initialize`, which happens
+before connection parameters are known. The UI runs discovery after a successful
+connection test and before loading database objects. Backend operations also
+resolve the same metadata, including operations issued through MCP.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 42,
+  "method": "get_connection_metadata",
+  "params": {
+    "params": {
+      "driver": "jdbc",
+      "connection_id": "example-connection",
+      "connection_uri": "jdbc:postgresql://localhost:5432/example",
+      "database": "example",
+      "username": "demo"
+    }
+  }
+}
+```
+
+The inner object follows the existing `ConnectionParams` contract. Credentials,
+tunnel parameters and plugin-specific fields are resolved through the normal
+host path. Do not log this object: it can contain passwords or credential-bearing
+URIs.
+
+An abbreviated response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 42,
+  "result": {
+    "capabilities": {
+      "schemas": true,
+      "views": true,
+      "routines": false,
+      "identifier_quote": "\"",
+      "sql_dialect": "postgres",
+      "manage_tables": false
+    },
+    "data_types": [
+      {
+        "name": "jsonb",
+        "category": "json",
+        "requires_length": false,
+        "requires_precision": false,
+        "supports_auto_increment": false
+      }
+    ],
+    "type_mappings": { "JSON": "jsonb" }
+  }
+}
+```
+
+`capabilities`, `data_types` and `type_mappings` may be omitted. Omitted fields
+retain their manifest values. An explicit `false` replaces `true`, and an empty
+type list or mapping replaces the static collection. Type mappings use uppercase
+keys, just like the manifest. `readonly: false` cannot lift a manifest-level
+read-only restriction.
+
+The allowed capability overrides are:
+
+- `schemas`, `views`, `materialized_views`, `routines`, `triggers`
+- `user_management`, `routine_management`, `explain`
+- `identifier_quote`, `sql_dialect`
+- `alter_primary_key`, `alter_column`, `create_foreign_keys`, `manage_tables`
+- `readonly`, `auto_increment_keyword`, `serial_type`, `inline_pk`
+
+Connection-form fields, plugin identity and executable settings cannot be
+overridden. Unknown fields, invalid field types and unknown SQL dialects are
+rejected. Identifier quoting currently accepts a double quote or backtick, as
+in the manifest schema. Do not forward JDBC's single-space value for unsupported
+quoting as a delimiter; omit the override and disable operations that cannot be
+implemented correctly with the fallback.
+
+Report capabilities that the plugin implements. A database supporting stored
+procedures does not justify `routines: true` when the plugin has no routine
+handlers. Type discovery likewise does not implement DDL or CRUD operations.
+
+## Implementing it in the JDBC bridge
+
+The existing dispatcher can reuse `withConnection`:
+
+```java
+case "get_connection_metadata" ->
+    withConnection(params, c -> ok(id, getConnectionMetadata(c)));
+```
+
+`getConnectionMetadata` can translate `c.getMetaData()` into the response:
+
+| JDBC metadata | Tabularis value |
+| --- | --- |
+| `getTypeInfo().TYPE_NAME` | Native type name |
+| `getTypeInfo().DATA_TYPE` | Category derived from `java.sql.Types` |
+| `getTypeInfo().CREATE_PARAMS` | Input for length/precision normalization |
+| `getTypeInfo().AUTO_INCREMENT` | Type-level auto-increment support |
+| `getIdentifierQuoteString()` | Supported identifier delimiter |
+| `supportsSchemasInDataManipulation()` and related methods | Schema behavior supported by the bridge |
+| `getTableTypes()` | Available table/view categories |
+
+See the [JDBC DatabaseMetaData contract](https://docs.oracle.com/en/java/javase/17/docs/api/java.sql/java/sql/DatabaseMetaData.html).
+`PRECISION` is a maximum, not a default length. `CREATE_PARAMS` does not always
+say whether a parameter is mandatory. Keep database-specific normalization where
+the JDBC information is insufficient, and use `generic` for an unknown SQL
+dialect.
+
+The bridge must route each request to a worker with the correct JDBC driver.
+The current prototype selects dependencies when it starts its first worker.
+Discovery does not fix that lifecycle issue; the bridge needs worker routing or
+driver loading that handles more than the first URL.
+
+For opted-in connections, SQL-building requests that previously lacked
+connection parameters also include the inner `params` object. This applies to
+`get_create_table_sql`, `get_add_column_sql`, `get_alter_column_sql`,
+`get_create_index_sql`, `routine_create_template` and `get_db_privilege_catalog`.
+The bridge can therefore select the same database when generating SQL. Static
+plugins receive the original request shapes.
+
+## Lifetime and errors
+
+The registered manifest stays immutable. Each operation receives a driver
+snapshot containing that connection's effective capabilities, types and type
+mappings. PostgreSQL and MySQL connections can use the same plugin process
+without overwriting each other's metadata.
+
+Successful discovery is cached per plugin process using the connection ID and
+a hash of the resolved parameters. The cache retains no raw credentials or
+URIs, is bounded to 128 entries, and shares concurrent discovery requests for
+the same parameters. A connection test or disconnect invalidates entries for
+that connection. Changed parameters produce a different key. Restarting the
+plugin creates a fresh cache.
+
+Editing a dynamic connection or explicitly reloading its plugin closes affected
+connection contexts in the UI. Reconnect to load fresh metadata. Late discovery
+responses cannot reopen a disconnected or invalidated context.
+
+Only a remote JSON-RPC `-32601` response falls back to the manifest. The host logs
+that the plugin declared a method it does not implement. Authentication errors,
+transport failures and invalid responses surface as discovery errors and are
+not cached as successful fallback results. Failed discovery can be retried.
+
+## Validation
+
+The automated stdio fixture exercises two engines, parameter forwarding,
+concurrent discovery, static-plugin compatibility, cache invalidation and error
+codes. It is a protocol fixture, not a replacement for testing the Java bridge
+against real databases.
+
+For an adapted JDBC bridge, check the following manually:
+
+1. Open PostgreSQL and another supported engine through the same plugin.
+2. Verify each connection's schema navigation, type list and SQL dialect.
+3. Switch between connections and confirm the metadata follows the connection.
+4. Edit a connection URL, reconnect and verify the previous metadata is gone.
+5. Restart the plugin, reconnect and verify discovery runs again.
+6. Confirm unsupported routine and DDL actions remain disabled.
+7. Repeat the normal workflow with a plugin that has no discovery opt-in.

--- a/plugins/PLUGIN_GUIDE.md
+++ b/plugins/PLUGIN_GUIDE.md
@@ -8,6 +8,10 @@ Tabularis supports extending its capabilities via a JSON-RPC based external plug
 
 This guide details how to implement and register a custom external plugin.
 
+Plugins that connect to more than one database engine can opt in to
+[connection metadata discovery](./CONNECTION_METADATA.md) to report capabilities
+and data types for each connection. Existing plugins keep their static manifests.
+
 ---
 
 ## 1. Plugin Architecture

--- a/plugins/manifest.schema.json
+++ b/plugins/manifest.schema.json
@@ -49,6 +49,11 @@
       "type": "string",
       "description": "Relative path to the plugin executable inside the plugin folder (without extension on Linux/macOS; Tabularis appends .exe on Windows automatically)."
     },
+    "connection_metadata": {
+      "type": "boolean",
+      "default": false,
+      "description": "Opt in to get_connection_metadata, which returns connection-specific capabilities, data_types and type_mappings. Static manifest values remain the fallback."
+    },
     "capabilities": {
       "type": "object",
       "description": "Feature flags that control which UI elements Tabularis renders for this driver.",
@@ -102,6 +107,16 @@
           "type": "boolean",
           "default": true,
           "description": "Optional capability for network drivers. Set false to hide connection string import in the UI."
+        },
+        "connection_uri": {
+          "type": "boolean",
+          "default": false,
+          "description": "Pass the connection URI verbatim to the driver instead of decomposing it into host, port and database fields."
+        },
+        "connection_uri_schemes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Additional URI schemes handled by this driver, such as jdbc."
         },
         "connectionString": {
           "type": "boolean",

--- a/src-tauri/src/clipboard_import.rs
+++ b/src-tauri/src/clipboard_import.rs
@@ -55,14 +55,18 @@ fn row_to_values_clause(row: &[Option<String>]) -> String {
     format!("({})", values.join(", "))
 }
 
-fn quote_identifier(name: &str) -> String {
-    format!("\"{}\"", name.replace('"', "\"\""))
+fn quote_identifier(name: &str, quote: &str) -> String {
+    format!("{quote}{}{quote}", name.replace(quote, &quote.repeat(2)))
 }
 
-fn table_ref(table_name: &str, schema: Option<&str>) -> String {
+fn table_ref(table_name: &str, schema: Option<&str>, quote: &str) -> String {
     match schema {
-        Some(s) => format!("{}.{}", quote_identifier(s), quote_identifier(table_name)),
-        None => quote_identifier(table_name),
+        Some(s) => format!(
+            "{}.{}",
+            quote_identifier(s, quote),
+            quote_identifier(table_name, quote)
+        ),
+        None => quote_identifier(table_name, quote),
     }
 }
 
@@ -86,8 +90,16 @@ pub async fn execute_clipboard_import<R: Runtime>(
         .await
         .ok_or_else(|| format!("Unsupported driver: {}", saved_conn.params.driver))?;
 
+    let dynamic_metadata = drv.has_connection_metadata();
+    let drv = drv.for_connection(&params).await?.unwrap_or(drv);
+    // Preserve the legacy import quoting for static drivers.
+    let quote = if dynamic_metadata {
+        drv.manifest().capabilities.identifier_quote.as_str()
+    } else {
+        "\""
+    };
     let schema_ref = req.schema.as_deref();
-    let tbl_ref = table_ref(&req.table_name, schema_ref);
+    let tbl_ref = table_ref(&req.table_name, schema_ref, quote);
     let mut table_created = false;
 
     if req.create_table {
@@ -99,8 +111,17 @@ pub async fn execute_clipboard_import<R: Runtime>(
                     .map_err(|e| format!("Failed to drop existing table: {e}"))?;
             }
             IfExistsStrategy::Append => {
-                add_new_columns(drv.as_ref(), &params, &req, schema_ref, &tbl_ref).await?;
-                return insert_rows(drv.as_ref(), &params, &req, schema_ref, &tbl_ref, false).await;
+                add_new_columns(drv.as_ref(), &params, &req, schema_ref, &tbl_ref, quote).await?;
+                return insert_rows(
+                    drv.as_ref(),
+                    &params,
+                    &req,
+                    schema_ref,
+                    &tbl_ref,
+                    quote,
+                    false,
+                )
+                .await;
             }
             IfExistsStrategy::Fail => {}
         }
@@ -117,10 +138,19 @@ pub async fn execute_clipboard_import<R: Runtime>(
         }
         table_created = true;
     } else {
-        add_new_columns(drv.as_ref(), &params, &req, schema_ref, &tbl_ref).await?;
+        add_new_columns(drv.as_ref(), &params, &req, schema_ref, &tbl_ref, quote).await?;
     }
 
-    insert_rows(drv.as_ref(), &params, &req, schema_ref, &tbl_ref, table_created).await
+    insert_rows(
+        drv.as_ref(),
+        &params,
+        &req,
+        schema_ref,
+        &tbl_ref,
+        quote,
+        table_created,
+    )
+    .await
 }
 
 async fn add_new_columns(
@@ -129,13 +159,14 @@ async fn add_new_columns(
     req: &ClipboardImportRequest,
     schema_ref: Option<&str>,
     tbl_ref: &str,
+    quote: &str,
 ) -> Result<(), String> {
     for col in &req.add_columns {
         let null_clause = if col.is_nullable { "" } else { " NOT NULL" };
         let sql = format!(
             "ALTER TABLE {} ADD COLUMN {} {}{}",
             tbl_ref,
-            quote_identifier(&col.name),
+            quote_identifier(&col.name, quote),
             col.data_type,
             null_clause,
         );
@@ -152,6 +183,7 @@ async fn insert_rows(
     req: &ClipboardImportRequest,
     schema_ref: Option<&str>,
     tbl_ref: &str,
+    quote: &str,
     table_created: bool,
 ) -> Result<ClipboardImportResult, String> {
     if req.rows.is_empty() {
@@ -161,7 +193,7 @@ async fn insert_rows(
     let col_list = req
         .columns
         .iter()
-        .map(|c| quote_identifier(&c.name))
+        .map(|c| quote_identifier(&c.name, quote))
         .collect::<Vec<_>>()
         .join(", ");
 
@@ -187,3 +219,7 @@ async fn insert_rows(
     log::info!("Clipboard import complete: {} rows inserted into {}", rows_inserted, tbl_ref);
     Ok(ClipboardImportResult { rows_inserted, table_created })
 }
+
+#[cfg(test)]
+#[path = "clipboard_import_tests.rs"]
+mod tests;

--- a/src-tauri/src/clipboard_import_tests.rs
+++ b/src-tauri/src/clipboard_import_tests.rs
@@ -1,0 +1,9 @@
+use super::*;
+
+#[test]
+fn import_identifiers_use_the_connection_quote_and_escape_delimiters() {
+    assert_eq!(quote_identifier("some\"table", "\""), "\"some\"\"table\"");
+    assert_eq!(quote_identifier("some`table", "`"), "`some``table`");
+    assert_eq!(table_ref("table", Some("schema"), "`"), "`schema`.`table`");
+    assert_eq!(table_ref("table", None, "\""), "\"table\"");
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -28,6 +28,50 @@ async fn driver_for(
         .ok_or_else(|| format!("Unsupported driver: {}", id))
 }
 
+async fn driver_for_params(
+    params: &ConnectionParams,
+) -> Result<Arc<dyn crate::drivers::driver_trait::DatabaseDriver>, String> {
+    crate::drivers::registry::get_connection_driver(params).await
+}
+
+/// Pure SQL builders still need no credentials for static drivers. Only
+/// discovery-enabled plugins resolve credentials and tunnels here.
+async fn driver_for_saved<R: Runtime>(
+    app: &AppHandle<R>,
+    saved: &SavedConnection,
+) -> Result<Arc<dyn crate::drivers::driver_trait::DatabaseDriver>, String> {
+    let driver = driver_for(&saved.params.driver).await?;
+    if !driver.has_connection_metadata() {
+        return Ok(driver);
+    }
+    let expanded = expand_ssh_connection_params(app, &saved.params).await?;
+    let expanded = expand_k8s_connection_params(app, &expanded).await?;
+    let params = resolve_connection_params_with_id(&expanded, &saved.id)?;
+    driver_for_params(&params).await
+}
+
+#[tauri::command]
+pub async fn get_connection_metadata<R: Runtime>(
+    app: AppHandle<R>,
+    connection_id: String,
+) -> Result<Option<crate::plugins::connection_metadata::ConnectionMetadata>, String> {
+    let saved = find_connection_by_id(&app, &connection_id)?;
+    if !driver_for(&saved.params.driver)
+        .await?
+        .has_connection_metadata()
+    {
+        return Ok(None);
+    }
+    let driver = driver_for_saved(&app, &saved).await?;
+    Ok(Some(
+        crate::plugins::connection_metadata::ConnectionMetadata {
+            capabilities: driver.manifest().capabilities.clone(),
+            data_types: driver.get_data_types(),
+            type_mappings: driver.manifest().type_mappings.clone(),
+        },
+    ))
+}
+
 const DEFAULT_MYSQL_PORT: u16 = 3306;
 const DEFAULT_POSTGRES_PORT: u16 = 5432;
 
@@ -734,7 +778,7 @@ pub async fn get_schemas<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.get_schemas(&params).await
 }
 
@@ -753,7 +797,7 @@ pub async fn get_available_databases<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.get_databases(&params).await
 }
 
@@ -807,7 +851,7 @@ pub async fn get_routines<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv.get_routines(&params, schema.as_deref()).await;
     let database = schema.as_deref().unwrap_or_else(|| params.database.primary());
 
@@ -837,7 +881,7 @@ pub async fn get_routine_parameters<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.get_routine_parameters(&params, &routine_name, schema.as_deref())
         .await
 }
@@ -862,7 +906,7 @@ pub async fn get_routine_definition<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.get_routine_definition(&params, &routine_name, &routine_type, schema.as_deref())
         .await
 }
@@ -881,7 +925,7 @@ pub async fn build_routine_call_sql<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.build_routine_call_sql(
         &params,
         &routine_name,
@@ -900,7 +944,7 @@ pub async fn get_routine_create_template<R: Runtime>(
     schema: Option<String>,
 ) -> Result<String, String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_saved(&app, &saved_conn).await?;
     drv.routine_create_template(&routine_type, schema.as_deref())
         .await
 }
@@ -918,7 +962,7 @@ pub async fn get_routine_edit_script<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.get_routine_edit_script(&params, &routine_name, &routine_type, schema.as_deref())
         .await
 }
@@ -943,7 +987,7 @@ pub async fn drop_routine<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.drop_routine(&params, &routine_name, &routine_type, schema.as_deref())
         .await
 }
@@ -958,7 +1002,7 @@ pub async fn get_schema_snapshot<R: Runtime>(
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.get_schema_snapshot(&params, schema.as_deref()).await
 }
 
@@ -972,7 +1016,7 @@ pub async fn get_ai_schema_context<R: Runtime>(
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
-    let driver = driver_for(&saved_conn.params.driver).await?;
+    let driver = driver_for_params(&params).await?;
     let identifier_quote = driver.manifest().capabilities.identifier_quote.as_str();
     let context = driver
         .get_ai_schema_context(
@@ -1145,7 +1189,8 @@ pub async fn update_connection<R: Runtime>(
         .unwrap_or(false);
     // A stored URI belongs to the driver that produced it. Switching drivers
     // must drop it rather than hand one driver's credentials to another.
-    let same_driver = conn_file.connections[conn_idx].params.driver == params.driver;
+    let previous_driver_id = conn_file.connections[conn_idx].params.driver.clone();
+    let same_driver = previous_driver_id == params.driver;
     let connection_uri = runtime_connection_uri(&params).map(str::to_owned);
     // The frontend sends the URI back only when the user retyped it. An edit
     // that leaves the field untouched must keep the stored secret; an edit that
@@ -1226,6 +1271,22 @@ pub async fn update_connection<R: Runtime>(
     persist_connection_uri_change(&cache, &id, existing_uri_in_keychain, uri_change, || {
         save_connections_and_invalidate(&app, &path, &conn_file)
     })?;
+
+    let mut metadata_changed = false;
+    for driver_id in [&previous_driver_id, &updated.params.driver] {
+        if let Some(driver) = crate::drivers::registry::get_driver(driver_id).await {
+            if driver.has_connection_metadata() {
+                driver.invalidate_connection_metadata(Some(&id)).await;
+                metadata_changed = true;
+            }
+        }
+    }
+    if metadata_changed {
+        let _ = app.emit(
+            "connection-metadata-invalidated",
+            serde_json::json!({"connectionId": id}),
+        );
+    }
 
     // On single→multi transition, associate existing favorites/history (with no
     // database set) to the original single database name.
@@ -2432,6 +2493,9 @@ pub async fn test_connection<R: Runtime>(
         );
         emit_test_failure(&app, progress_id, "dbConnect", e)
     })?;
+
+    drv.invalidate_connection_metadata(resolved_params.connection_id.as_deref())
+        .await;
 
     emit_test_progress(&app, progress_id, "dbConnect", "ok", None);
     log::info!(
@@ -3693,7 +3757,7 @@ pub async fn get_tables<R: Runtime>(
         params.database
     );
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv.get_tables(&params, schema.as_deref()).await;
 
     match &result {
@@ -3715,7 +3779,7 @@ pub async fn get_columns<R: Runtime>(
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.get_columns(&params, &table_name, schema.as_deref())
         .await
 }
@@ -3731,7 +3795,7 @@ pub async fn get_foreign_keys<R: Runtime>(
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.get_foreign_keys(&params, &table_name, schema.as_deref())
         .await
 }
@@ -3747,7 +3811,7 @@ pub async fn get_indexes<R: Runtime>(
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.get_indexes(&params, &table_name, schema.as_deref())
         .await
 }
@@ -3774,7 +3838,7 @@ pub async fn delete_record<R: Runtime>(
     if let Some(db) = database {
         params.database = crate::models::DatabaseSelection::Single(db);
     }
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.delete_record(&params, &table, &pk_map, schema.as_deref())
         .await
 }
@@ -3806,7 +3870,7 @@ pub async fn update_record<R: Runtime>(
         params.database = crate::models::DatabaseSelection::Single(db);
     }
     let max_blob_size = crate::config::get_max_blob_size(&app);
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.update_record(
         &params,
         &table,
@@ -3833,7 +3897,7 @@ pub async fn save_blob_to_file<R: Runtime>(
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.save_blob_to_file(
         &params,
         &table,
@@ -3860,7 +3924,7 @@ pub async fn fetch_blob_as_data_url<R: Runtime>(
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let wire = drv
         .fetch_blob_as_data_url(
             &params,
@@ -4059,7 +4123,7 @@ pub async fn insert_record<R: Runtime>(
         params.database = crate::models::DatabaseSelection::Single(db);
     }
     let max_blob_size = crate::config::get_max_blob_size(&app);
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.insert_record(&params, &table, data, schema.as_deref(), max_blob_size)
         .await
 }
@@ -4150,7 +4214,7 @@ pub async fn execute_query<R: Runtime>(
     // Cheap: only allocates when the statement really is a DROP DATABASE.
     let dropped = crate::sql_database_statements::dropped_database(&sanitized_query);
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let task = tokio::spawn(async move {
         drv.execute_query(
             &params,
@@ -4248,7 +4312,7 @@ pub async fn execute_query_batch<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
 
     // Build a Tauri-agnostic progress sink the driver invokes per statement.
     // Each invocation emits one event so result tabs resolve as they finish.
@@ -4352,7 +4416,7 @@ pub async fn explain_query_plan<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let task = tokio::spawn(async move {
         drv.explain_query(&params, &sanitized_query, analyze, schema.as_deref())
             .await
@@ -4399,7 +4463,7 @@ pub async fn count_query<R: Runtime>(
 
     let count_q = format!("SELECT COUNT(*) FROM ({}) as count_wrapper", sanitized);
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv
         .execute_query(&params, &count_q, None, 1, schema.as_deref())
         .await?;
@@ -4693,7 +4757,7 @@ pub async fn get_views<R: Runtime>(
         params.database
     );
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv.get_views(&params, schema.as_deref()).await;
 
     match &result {
@@ -4722,7 +4786,7 @@ pub async fn get_view_definition<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv
         .get_view_definition(&params, &view_name, schema.as_deref())
         .await;
@@ -4754,7 +4818,7 @@ pub async fn create_view<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv
         .create_view(&params, &view_name, &definition, schema.as_deref())
         .await;
@@ -4786,7 +4850,7 @@ pub async fn alter_view<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv
         .alter_view(&params, &view_name, &definition, schema.as_deref())
         .await;
@@ -4817,7 +4881,7 @@ pub async fn drop_view<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv.drop_view(&params, &view_name, schema.as_deref()).await;
 
     match &result {
@@ -4846,7 +4910,7 @@ pub async fn get_view_columns<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv
         .get_view_columns(&params, &view_name, schema.as_deref())
         .await;
@@ -4872,7 +4936,7 @@ pub async fn get_materialized_views<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv.get_materialized_views(&params, schema.as_deref()).await;
 
     match &result {
@@ -4909,7 +4973,7 @@ pub async fn get_materialized_view_columns<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv
         .get_materialized_view_columns(&params, &view_name, schema.as_deref())
         .await;
@@ -4948,7 +5012,7 @@ pub async fn get_materialized_view_definition<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv
         .get_materialized_view_definition(&params, &view_name, schema.as_deref())
         .await;
@@ -4986,7 +5050,7 @@ pub async fn refresh_materialized_view<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv
         .refresh_materialized_view(&params, &view_name, schema.as_deref())
         .await;
@@ -5012,7 +5076,7 @@ pub async fn get_triggers<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv.get_triggers(&params, schema.as_deref()).await;
 
     match &result {
@@ -5042,7 +5106,7 @@ pub async fn get_trigger_definition<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.get_trigger_definition(&params, &trigger_name, &table_name, schema.as_deref())
         .await
 }
@@ -5061,7 +5125,7 @@ pub async fn create_trigger<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv
         .create_trigger(&params, &trigger_sql, schema.as_deref())
         .await;
@@ -5093,7 +5157,7 @@ pub async fn drop_trigger<R: Runtime>(
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv
         .drop_trigger(&params, &trigger_name, &table_name, schema.as_deref())
         .await;
@@ -5123,7 +5187,7 @@ async fn user_mgmt_context<R: Runtime>(
     let expanded_params = expand_ssh_connection_params(app, &saved_conn.params).await?;
     let expanded_params = expand_k8s_connection_params(app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     Ok((drv, params))
 }
 
@@ -5133,7 +5197,7 @@ pub async fn get_db_privilege_catalog<R: Runtime>(
     connection_id: String,
 ) -> Result<crate::models::DbPrivilegeCatalog, String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_saved(&app, &saved_conn).await?;
     drv.get_db_privilege_catalog().await
 }
 
@@ -5283,6 +5347,11 @@ pub async fn disconnect_connection<R: Runtime>(
     crate::health_check::unregister_connection(&connection_id).await;
 
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
+    if let Some(driver) = crate::drivers::registry::get_driver(&saved_conn.params.driver).await {
+        driver
+            .invalidate_connection_metadata(Some(&connection_id))
+            .await;
+    }
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
@@ -5315,11 +5384,21 @@ pub async fn get_data_types(driver: String) -> Result<crate::models::DataTypeReg
 /// Maps generic inferred types (emitted by the clipboard parser) to
 /// driver-specific type names. Returns names in the same order as `kinds`.
 #[tauri::command]
-pub async fn map_inferred_column_types(
+pub async fn map_inferred_column_types<R: Runtime>(
+    app: AppHandle<R>,
     driver: String,
     kinds: Vec<String>,
+    connection_id: Option<String>,
 ) -> Result<Vec<String>, String> {
-    let drv = driver_for(&driver).await?;
+    let drv = if let Some(id) = connection_id {
+        let saved = find_connection_by_id(&app, &id)?;
+        if saved.params.driver != driver {
+            return Err("Connection driver does not match the requested driver".into());
+        }
+        driver_for_saved(&app, &saved).await?
+    } else {
+        driver_for(&driver).await?
+    };
     Ok(kinds.iter().map(|k| drv.map_inferred_type(k)).collect())
 }
 
@@ -5334,7 +5413,7 @@ pub async fn get_create_table_sql<R: Runtime>(
     schema: Option<String>,
 ) -> Result<Vec<String>, String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_saved(&app, &saved_conn).await?;
     drv.get_create_table_sql(&table_name, columns, schema.as_deref())
         .await
 }
@@ -5348,7 +5427,7 @@ pub async fn get_add_column_sql<R: Runtime>(
     schema: Option<String>,
 ) -> Result<Vec<String>, String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_saved(&app, &saved_conn).await?;
     drv.get_add_column_sql(&table, column, schema.as_deref())
         .await
 }
@@ -5363,7 +5442,7 @@ pub async fn get_alter_column_sql<R: Runtime>(
     schema: Option<String>,
 ) -> Result<Vec<String>, String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_saved(&app, &saved_conn).await?;
     drv.get_alter_column_sql(&table, old_column, new_column, schema.as_deref())
         .await
 }
@@ -5379,7 +5458,7 @@ pub async fn get_create_index_sql<R: Runtime>(
     schema: Option<String>,
 ) -> Result<Vec<String>, String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_saved(&app, &saved_conn).await?;
     drv.get_create_index_sql(&table, &index_name, columns, is_unique, schema.as_deref())
         .await
 }
@@ -5398,7 +5477,7 @@ pub async fn get_create_foreign_key_sql<R: Runtime>(
     schema: Option<String>,
 ) -> Result<Vec<String>, String> {
     let saved_conn = find_connection_by_id(&app, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_saved(&app, &saved_conn).await?;
     drv.get_create_foreign_key_sql(
         &saved_conn.params,
         &table,
@@ -5425,7 +5504,7 @@ pub async fn drop_index_action<R: Runtime>(
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.drop_index(&params, &table, &index_name, schema.as_deref())
         .await
 }
@@ -5442,7 +5521,7 @@ pub async fn drop_foreign_key_action<R: Runtime>(
     let expanded_params = expand_ssh_connection_params(&app, &saved_conn.params).await?;
     let expanded_params = expand_k8s_connection_params(&app, &expanded_params).await?;
     let params = resolve_connection_params_with_id(&expanded_params, &connection_id)?;
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     drv.drop_foreign_key(&params, &table, &fk_name, schema.as_deref())
         .await
 }
@@ -5478,10 +5557,15 @@ pub async fn save_keybindings<R: Runtime>(
 #[tauri::command]
 pub async fn get_driver_manifest(
     driver_id: String,
-) -> Option<crate::drivers::driver_trait::PluginManifest> {
+) -> Option<crate::plugins::connection_metadata::DriverManifestDetails> {
     crate::drivers::registry::get_driver(&driver_id)
         .await
-        .map(|d| d.manifest().clone())
+        .map(
+            |d| crate::plugins::connection_metadata::DriverManifestDetails {
+                manifest: d.manifest().clone(),
+                connection_metadata: d.has_connection_metadata().then_some(true),
+            },
+        )
 }
 
 // ==================== Connection Groups Management ====================
@@ -5843,7 +5927,7 @@ pub async fn get_server_now<R: Runtime>(
         _ => "SELECT NOW()",
     };
 
-    let drv = driver_for(&saved_conn.params.driver).await?;
+    let drv = driver_for_params(&params).await?;
     let result = drv.execute_query(&params, query, Some(1), 1, None).await?;
 
     result

--- a/src-tauri/src/drivers/driver_trait.rs
+++ b/src-tauri/src/drivers/driver_trait.rs
@@ -329,6 +329,22 @@ pub trait DatabaseDriver: Send + Sync {
 
     fn manifest(&self) -> &PluginManifest;
 
+    fn has_connection_metadata(&self) -> bool {
+        false
+    }
+
+    /// Optionally bind connection-dependent metadata to an isolated driver
+    /// snapshot. Static drivers retain the registered instance and make no RPC.
+    async fn for_connection(
+        &self,
+        _params: &ConnectionParams,
+    ) -> Result<Option<std::sync::Arc<dyn DatabaseDriver>>, String> {
+        Ok(None)
+    }
+
+    /// Drop cached discovery results on reconnect. Static drivers do nothing.
+    async fn invalidate_connection_metadata(&self, _connection_id: Option<&str>) {}
+
     /// Returns the list of data types supported by this driver.
     fn get_data_types(&self) -> Vec<DataTypeInfo>;
 

--- a/src-tauri/src/drivers/registry.rs
+++ b/src-tauri/src/drivers/registry.rs
@@ -31,6 +31,16 @@ pub async fn get_driver(id: &str) -> Option<Arc<dyn DatabaseDriver>> {
     reg.get(id).cloned()
 }
 
+/// Resolve an isolated metadata snapshot only for drivers that opt in.
+pub async fn get_connection_driver(
+    params: &crate::models::ConnectionParams,
+) -> Result<Arc<dyn DatabaseDriver>, String> {
+    let driver = get_driver(&params.driver)
+        .await
+        .ok_or_else(|| format!("Unsupported driver: {}", params.driver))?;
+    Ok(driver.for_connection(params).await?.unwrap_or(driver))
+}
+
 /// Unregister a driver by its id. Shuts down its background process (if any)
 /// and returns `true` if a driver was removed.
 pub async fn unregister_driver(id: &str) -> bool {

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -215,6 +215,7 @@ where
     let driver = crate::drivers::registry::get_driver(driver_id)
         .await
         .ok_or_else(|| format!("Unsupported driver for export: {driver_id}"))?;
+    let driver = driver.for_connection(params).await?.unwrap_or(driver);
 
     let mut page: u32 = 1;
     loop {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -430,6 +430,7 @@ pub fn run() {
             close_devtools,
             commands::get_registered_drivers,
             commands::get_driver_manifest,
+            commands::get_connection_metadata,
             commands::get_keybindings,
             commands::save_keybindings,
             commands::test_connection,

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -348,11 +348,11 @@ async fn resolve_db_driver(
     JsonRpcError,
 > {
     let (conn, db_params) = resolve_db_params(conn_id).await?;
-    let driver = driver_registry::get_driver(&conn.params.driver)
+    let driver = driver_registry::get_connection_driver(&db_params)
         .await
-        .ok_or_else(|| JsonRpcError {
+        .map_err(|message| JsonRpcError {
             code: -32000,
-            message: format!("Unsupported driver: {}", conn.params.driver),
+            message,
             data: None,
         })?;
     Ok((conn, db_params, driver))

--- a/src-tauri/src/plugins/commands.rs
+++ b/src-tauri/src/plugins/commands.rs
@@ -222,6 +222,8 @@ pub async fn install_plugin(
         .await
         .map_err(|e| format!("Plugin installed but failed to load: {}", e))?;
 
+    crate::plugins::connection_metadata::notify_plugin_reload(&app, &plugin_id).await;
+
     Ok(())
 }
 
@@ -270,6 +272,7 @@ pub async fn enable_plugin(app: AppHandle, plugin_id: String) -> Result<(), Stri
     }
     crate::plugins::manager::load_plugin_from_dir(&plugin_dir, interpreter_override, settings)
         .await?;
+    crate::plugins::connection_metadata::notify_plugin_reload(&app, &plugin_id).await;
     Ok(())
 }
 

--- a/src-tauri/src/plugins/connection_metadata.rs
+++ b/src-tauri/src/plugins/connection_metadata.rs
@@ -1,0 +1,188 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::sync::{Mutex, OnceCell};
+
+use crate::drivers::driver_trait::{DriverCapabilities, PluginManifest, SqlDialect};
+use crate::models::{ConnectionParams, DataTypeInfo};
+
+/// Adds discovery support to the single-driver command without changing the
+/// serialized manifest of static drivers or the registered manifest itself.
+#[derive(Serialize)]
+pub struct DriverManifestDetails {
+    #[serde(flatten)]
+    pub manifest: PluginManifest,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection_metadata: Option<bool>,
+}
+
+/// The UI invalidates only discovery-enabled contexts. Emitting for every
+/// replacement also covers an update that removes a plugin's discovery opt-in.
+pub async fn notify_plugin_reload<R: tauri::Runtime>(app: &tauri::AppHandle<R>, driver_id: &str) {
+    use tauri::Emitter;
+    let _ = app.emit(
+        "connection-metadata-invalidated",
+        serde_json::json!({"driverId": driver_id}),
+    );
+}
+
+/// Only connection-dependent fields belong here. Connection-form fields and
+/// plugin identity always come from the installed manifest.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConnectionCapabilityOverrides {
+    pub schemas: Option<bool>,
+    pub views: Option<bool>,
+    pub materialized_views: Option<bool>,
+    pub routines: Option<bool>,
+    pub triggers: Option<bool>,
+    pub user_management: Option<bool>,
+    pub routine_management: Option<bool>,
+    pub identifier_quote: Option<String>,
+    pub sql_dialect: Option<SqlDialect>,
+    pub alter_primary_key: Option<bool>,
+    pub alter_column: Option<bool>,
+    pub create_foreign_keys: Option<bool>,
+    pub manage_tables: Option<bool>,
+    pub readonly: Option<bool>,
+    pub explain: Option<bool>,
+    pub auto_increment_keyword: Option<String>,
+    pub serial_type: Option<String>,
+    pub inline_pk: Option<bool>,
+}
+
+impl ConnectionCapabilityOverrides {
+    pub fn apply(&self, base: &DriverCapabilities) -> Result<DriverCapabilities, String> {
+        let mut result = base.clone();
+        macro_rules! apply {
+            ($($field:ident),+ $(,)?) => { $(
+                if let Some(value) = &self.$field {
+                    result.$field = value.clone();
+                }
+            )+ };
+        }
+        apply!(
+            schemas,
+            views,
+            materialized_views,
+            routines,
+            triggers,
+            user_management,
+            routine_management,
+            identifier_quote,
+            alter_primary_key,
+            alter_column,
+            create_foreign_keys,
+            manage_tables,
+            explain,
+            auto_increment_keyword,
+            serial_type,
+            inline_pk
+        );
+        if let Some(dialect) = self.sql_dialect {
+            result.sql_dialect = Some(dialect);
+        }
+        // Discovery cannot lift a manifest-level read-only restriction.
+        result.readonly = base.readonly || self.readonly.unwrap_or(false);
+        if let Some(quote) = &self.identifier_quote {
+            if !matches!(quote.as_str(), "\"" | "`") {
+                return Err(
+                    "connection metadata identifier_quote must be a double quote or backtick"
+                        .into(),
+                );
+            }
+        }
+        Ok(result)
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConnectionMetadataOverrides {
+    #[serde(default)]
+    pub capabilities: ConnectionCapabilityOverrides,
+    pub data_types: Option<Vec<DataTypeInfo>>,
+    pub type_mappings: Option<HashMap<String, String>>,
+}
+
+/// A connection-local snapshot. Never inserted into the driver registry.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConnectionMetadata {
+    pub capabilities: DriverCapabilities,
+    pub data_types: Vec<DataTypeInfo>,
+    pub type_mappings: HashMap<String, String>,
+}
+
+impl ConnectionMetadataOverrides {
+    pub fn resolve(
+        &self,
+        manifest: &PluginManifest,
+        data_types: &[DataTypeInfo],
+    ) -> Result<ConnectionMetadata, String> {
+        let types = self.data_types.as_deref().unwrap_or(data_types);
+        if self.data_types.is_some() {
+            for ty in types {
+                if ty.name.trim().is_empty()
+                    || !matches!(
+                        ty.category.as_str(),
+                        "numeric" | "string" | "date" | "binary" | "json" | "spatial" | "other"
+                    )
+                {
+                    return Err(
+                        "connection metadata contains an invalid data type name or category".into(),
+                    );
+                }
+            }
+        }
+        Ok(ConnectionMetadata {
+            capabilities: self.capabilities.apply(&manifest.capabilities)?,
+            data_types: types.to_vec(),
+            type_mappings: self
+                .type_mappings
+                .clone()
+                .unwrap_or_else(|| manifest.type_mappings.clone()),
+        })
+    }
+}
+
+type MetadataCell = Arc<OnceCell<ConnectionMetadata>>;
+
+/// Per-process cache, bounded for temporary connections. Keys retain connection
+/// IDs and parameter hashes, never URLs, passwords, or serialized parameters.
+#[derive(Default)]
+pub struct ConnectionMetadataCache {
+    entries: Mutex<HashMap<(Option<String>, [u8; 32]), MetadataCell>>,
+}
+
+impl ConnectionMetadataCache {
+    pub async fn entry(&self, params: &ConnectionParams) -> Result<MetadataCell, String> {
+        // Serializing through Value sorts object keys, including plugin extras.
+        let value = serde_json::to_value(params).map_err(|e| e.to_string())?;
+        let bytes = serde_json::to_vec(&value).map_err(|e| e.to_string())?;
+        let fingerprint: [u8; 32] = Sha256::digest(&bytes).into();
+        let key = (params.connection_id.clone(), fingerprint);
+        let mut entries = self.entries.lock().await;
+        if let Some(entry) = entries.get(&key) {
+            return Ok(entry.clone());
+        }
+        if entries.len() >= 128 {
+            entries.clear();
+        }
+        let cell = Arc::new(OnceCell::new());
+        entries.insert(key, cell.clone());
+        Ok(cell)
+    }
+
+    pub async fn invalidate(&self, connection_id: Option<&str>) {
+        self.entries
+            .lock()
+            .await
+            .retain(|(id, _), _| id.as_deref() != connection_id);
+    }
+}
+
+#[cfg(test)]
+#[path = "connection_metadata_tests.rs"]
+mod tests;

--- a/src-tauri/src/plugins/connection_metadata_tests.rs
+++ b/src-tauri/src/plugins/connection_metadata_tests.rs
@@ -1,0 +1,312 @@
+use super::*;
+use crate::drivers::driver_trait::DatabaseDriver;
+use crate::models::RoutineCallArg;
+use crate::plugins::driver::RpcDriver;
+use crate::plugins::manager::ConfigManifest;
+use serde_json::json;
+
+fn manifest() -> PluginManifest {
+    serde_json::from_value(json!({
+        "id": "jdbc-test", "name": "JDBC test", "version": "1.0.0",
+        "description": "", "default_port": null,
+        "capabilities": {
+            "schemas": true, "views": true, "routines": false,
+            "file_based": false, "identifier_quote": "\"", "alter_primary_key": false
+        },
+        "type_mappings": { "JSON": "TEXT" }
+    }))
+    .unwrap()
+}
+
+fn types() -> Vec<DataTypeInfo> {
+    serde_json::from_value(json!([{
+        "name": "TEXT", "category": "string", "requires_length": false,
+        "requires_precision": false
+    }]))
+    .unwrap()
+}
+
+fn params(uri: &str) -> ConnectionParams {
+    ConnectionParams {
+        driver: "jdbc-test".into(),
+        connection_id: Some("connection-one".into()),
+        connection_uri: Some(uri.into()),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn omitted_fields_preserve_static_metadata() {
+    let base = manifest();
+    let resolved = ConnectionMetadataOverrides::default()
+        .resolve(&base, &types())
+        .unwrap();
+    assert_eq!(
+        serde_json::to_value(&resolved.capabilities).unwrap(),
+        serde_json::to_value(&base.capabilities).unwrap()
+    );
+    assert_eq!(resolved.data_types[0].name, "TEXT");
+    assert_eq!(resolved.type_mappings["JSON"], "TEXT");
+}
+
+#[test]
+fn explicit_false_and_empty_collections_replace_defaults() {
+    let overrides: ConnectionMetadataOverrides = serde_json::from_value(json!({
+        "capabilities": { "schemas": false, "views": false, "manage_tables": false },
+        "data_types": [], "type_mappings": {}
+    }))
+    .unwrap();
+    let base = manifest();
+    let resolved = overrides.resolve(&base, &types()).unwrap();
+    assert!(!resolved.capabilities.schemas);
+    assert!(!resolved.capabilities.views);
+    assert!(!resolved.capabilities.manage_tables);
+    assert!(resolved.data_types.is_empty());
+    assert!(resolved.type_mappings.is_empty());
+    assert!(base.capabilities.schemas);
+}
+
+#[test]
+fn metadata_cannot_change_connection_setup_or_lift_readonly() {
+    for field in [
+        "file_based",
+        "connection_uri",
+        "supports_ssl",
+        "no_connection_required",
+    ] {
+        let mut capabilities = serde_json::Map::new();
+        capabilities.insert(field.into(), json!(true));
+        assert!(serde_json::from_value::<ConnectionMetadataOverrides>(
+            json!({"capabilities": capabilities})
+        )
+        .is_err());
+    }
+    let mut base = manifest();
+    base.capabilities.readonly = true;
+    let overrides: ConnectionMetadataOverrides =
+        serde_json::from_value(json!({"capabilities": {"readonly": false}})).unwrap();
+    assert!(
+        overrides
+            .resolve(&base, &types())
+            .unwrap()
+            .capabilities
+            .readonly
+    );
+}
+
+#[test]
+fn invalid_types_quotes_and_dialects_are_rejected() {
+    for payload in [
+        json!({"capabilities": {"schemas": "yes"}}),
+        json!({"capabilities": {"sql_dialect": "unknown"}}),
+        json!({"data_types": [{}]}),
+        json!(null),
+    ] {
+        assert!(serde_json::from_value::<ConnectionMetadataOverrides>(payload).is_err());
+    }
+    for payload in [
+        json!({"capabilities": {"identifier_quote": " "}}),
+        json!({"data_types": [{"name": "", "category": "string", "requires_length": false, "requires_precision": false}]}),
+    ] {
+        let overrides: ConnectionMetadataOverrides = serde_json::from_value(payload).unwrap();
+        assert!(overrides.resolve(&manifest(), &types()).is_err());
+    }
+}
+
+#[test]
+fn static_manifest_wire_shape_and_opt_in_default_are_unchanged() {
+    let base = manifest();
+    let details = DriverManifestDetails {
+        manifest: base.clone(),
+        connection_metadata: None,
+    };
+    assert_eq!(
+        serde_json::to_value(details).unwrap(),
+        serde_json::to_value(base).unwrap()
+    );
+    let config: ConfigManifest = serde_json::from_value(json!({
+        "name": "old-plugin", "version": "1.0.0", "description": "", "executable": "driver"
+    }))
+    .unwrap();
+    assert!(!config.connection_metadata);
+}
+
+#[tokio::test]
+async fn cache_distinguishes_connection_parameters_and_canonicalizes_extras() {
+    let cache = ConnectionMetadataCache::default();
+    let original = params("jdbc:postgresql://localhost/one");
+    let first = cache.entry(&original).await.unwrap();
+    assert!(Arc::ptr_eq(&first, &cache.entry(&original).await.unwrap()));
+    let mut changed = original.clone();
+    changed.password = Some("changed".into());
+    assert!(!Arc::ptr_eq(&first, &cache.entry(&changed).await.unwrap()));
+    changed = original.clone();
+    changed.connection_id = Some("another-connection".into());
+    let other_connection = cache.entry(&changed).await.unwrap();
+    assert!(!Arc::ptr_eq(&first, &other_connection));
+    let mut a = original.clone();
+    a.extra.insert("a".into(), "1".into());
+    a.extra.insert("b".into(), "2".into());
+    let mut b = original.clone();
+    b.extra.insert("b".into(), "2".into());
+    b.extra.insert("a".into(), "1".into());
+    assert!(Arc::ptr_eq(
+        &cache.entry(&a).await.unwrap(),
+        &cache.entry(&b).await.unwrap()
+    ));
+    cache.invalidate(Some("connection-one")).await;
+    assert!(!Arc::ptr_eq(&first, &cache.entry(&original).await.unwrap()));
+    assert!(Arc::ptr_eq(
+        &other_connection,
+        &cache.entry(&changed).await.unwrap()
+    ));
+}
+
+#[tokio::test]
+async fn clearing_cache_detaches_inflight_results_and_bounds_temporary_connections() {
+    let cache = ConnectionMetadataCache::default();
+    let params = params("jdbc:postgresql://localhost/one");
+    let old = cache.entry(&params).await.unwrap();
+    cache.invalidate(Some("connection-one")).await;
+    let current = cache.entry(&params).await.unwrap();
+    old.set(
+        ConnectionMetadataOverrides::default()
+            .resolve(&manifest(), &types())
+            .unwrap(),
+    )
+    .unwrap();
+    assert!(current.get().is_none());
+    for i in 0..200 {
+        let mut next = params.clone();
+        next.connection_id = Some(i.to_string());
+        cache.entry(&next).await.unwrap();
+    }
+    assert!(cache.entries.lock().await.len() <= 128);
+}
+
+async fn rpc_driver(enabled: bool) -> RpcDriver {
+    RpcDriver::new(
+        manifest(),
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/connection_metadata_plugin.py"),
+        Some(if cfg!(windows) { "python" } else { "python3" }.into()),
+        types(),
+        HashMap::new(),
+    )
+    .await
+    .unwrap()
+    .with_connection_metadata(enabled)
+}
+
+#[tokio::test]
+async fn static_plugin_receives_no_discovery_rpc() {
+    let driver = rpc_driver(false).await;
+    let params = params("jdbc:postgresql://localhost/one");
+    assert!(driver.for_connection(&params).await.unwrap().is_none());
+    assert_eq!(driver.get_databases(&params).await.unwrap(), ["0"]);
+    assert_eq!(
+        driver
+            .get_create_table_sql("example", Vec::new(), None)
+            .await
+            .unwrap(),
+        ["no-connection-params"]
+    );
+    driver.shutdown().await;
+}
+
+#[tokio::test]
+async fn rpc_snapshots_isolate_types_dialect_and_sql_fallbacks() {
+    let driver = rpc_driver(true).await;
+    let pg = params("jdbc:postgresql://localhost/one");
+    let mysql = params("jdbc:mysql://localhost/two");
+    let (one, two) = tokio::join!(driver.for_connection(&pg), driver.for_connection(&mysql));
+    let one = one.unwrap().unwrap();
+    let two = two.unwrap().unwrap();
+    assert!(one.manifest().capabilities.schemas);
+    assert!(!two.manifest().capabilities.schemas);
+    assert_eq!(
+        one.manifest().capabilities.sql_dialect,
+        Some(SqlDialect::Postgres)
+    );
+    assert_eq!(
+        two.manifest().capabilities.sql_dialect,
+        Some(SqlDialect::Mysql)
+    );
+    assert_eq!(one.get_data_types()[0].name, "JSONB");
+    assert_eq!(two.get_data_types()[0].name, "JSON");
+    assert_eq!(one.map_inferred_type("json"), "JSONB");
+    assert_eq!(driver.get_data_types()[0].name, "TEXT");
+    assert_eq!(
+        one.get_create_table_sql("example", Vec::new(), None)
+            .await
+            .unwrap(),
+        [pg.connection_uri.clone().unwrap()]
+    );
+    assert_eq!(
+        two.get_create_table_sql("example", Vec::new(), None)
+            .await
+            .unwrap(),
+        [mysql.connection_uri.clone().unwrap()]
+    );
+    // The command supplies saved parameters; discovery resolved the runtime URI.
+    let unresolved = ConnectionParams::default();
+    assert_eq!(
+        one.get_create_foreign_key_sql(
+            &unresolved,
+            "example",
+            "fk",
+            "parent_id",
+            "parent",
+            "id",
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap(),
+        [pg.connection_uri.clone().unwrap()]
+    );
+    let args: Vec<RoutineCallArg> = Vec::new();
+    let sql = two
+        .build_routine_call_sql(&mysql, "example", "PROCEDURE", &args, None)
+        .await
+        .unwrap();
+    assert!(sql.contains("`example`"), "{sql}");
+    driver.shutdown().await;
+}
+
+#[tokio::test]
+async fn concurrent_discovery_is_shared_and_reconnect_refreshes() {
+    let driver = rpc_driver(true).await;
+    let params = params("jdbc:postgresql://localhost/one");
+    let (a, b) = tokio::join!(
+        driver.for_connection(&params),
+        driver.for_connection(&params)
+    );
+    a.unwrap();
+    b.unwrap();
+    assert_eq!(driver.get_databases(&params).await.unwrap(), ["1"]);
+    driver
+        .invalidate_connection_metadata(params.connection_id.as_deref())
+        .await;
+    driver.for_connection(&params).await.unwrap();
+    assert_eq!(driver.get_databases(&params).await.unwrap(), ["2"]);
+    driver.shutdown().await;
+}
+
+#[tokio::test]
+async fn only_remote_method_not_found_falls_back() {
+    let driver = rpc_driver(true).await;
+    let mut params = params("jdbc:postgresql://localhost/one");
+    params.extra.insert("case".into(), "missing".into());
+    let snapshot = driver.for_connection(&params).await.unwrap().unwrap();
+    assert_eq!(snapshot.get_data_types()[0].name, "TEXT");
+    for case in ["failure", "malformed", "null"] {
+        params.extra.insert("case".into(), case.into());
+        assert!(driver.for_connection(&params).await.is_err(), "{case}");
+    }
+    // Failures are retried, rather than poisoning the cache with defaults.
+    driver.for_connection(&params).await.err().unwrap();
+    assert_eq!(driver.get_databases(&params).await.unwrap(), ["5"]);
+    driver.shutdown().await;
+}

--- a/src-tauri/src/plugins/driver.rs
+++ b/src-tauri/src/plugins/driver.rs
@@ -17,7 +17,8 @@ use crate::models::{
     RawExplainOutput, RoutineInfo, RoutineParameter, TableColumn, TableInfo, TableSchema,
     TriggerInfo, ViewInfo,
 };
-use crate::plugins::rpc::{JsonRpcRequest, JsonRpcResponse};
+use crate::plugins::connection_metadata::{ConnectionMetadataCache, ConnectionMetadataOverrides};
+use crate::plugins::rpc::{JsonRpcRequest, JsonRpcResponse, PluginCallError};
 
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
@@ -46,7 +47,10 @@ fn is_method_not_found(err: &str) -> bool {
 /// Message sent to the management task that owns the plugin child process.
 enum PluginCommand {
     /// Dispatch a JSON-RPC request and route the response back via the sender.
-    Call(JsonRpcRequest, oneshot::Sender<Result<Value, String>>),
+    Call(
+        JsonRpcRequest,
+        oneshot::Sender<Result<Value, PluginCallError>>,
+    ),
     /// Drop the pending entry for `id` because the caller stopped waiting
     /// (timed out). Prevents an unbounded leak of orphaned response senders.
     Cancel(u64),
@@ -107,8 +111,10 @@ impl PluginProcess {
             let stdout = child.stdout.take().expect("Failed to open stdout");
             let mut reader = BufReader::new(stdout);
 
-            let mut pending_requests: HashMap<u64, oneshot::Sender<Result<Value, String>>> =
-                HashMap::new();
+            let mut pending_requests: HashMap<
+                u64,
+                oneshot::Sender<Result<Value, PluginCallError>>,
+            > = HashMap::new();
             let mut line_buf = String::new();
 
             loop {
@@ -130,7 +136,7 @@ impl PluginProcess {
                                 if let Err(e) = stdin.write_all(req_str.as_bytes()).await {
                                     log::error!("Failed to write to plugin stdin: {}", e);
                                     if let Some(tx) = pending_requests.remove(&id) {
-                                        let _ = tx.send(Err(format!("Plugin communication error: {}", e)));
+                                        let _ = tx.send(Err(format!("Plugin communication error: {}", e).into()));
                                     }
                                 }
                             }
@@ -162,7 +168,7 @@ impl PluginProcess {
                                     }
                                     Ok(JsonRpcResponse::Error { error, id, .. }) => {
                                         if let Some(tx) = pending_requests.remove(&id) {
-                                            let _ = tx.send(Err(error.message));
+                                            let _ = tx.send(Err(PluginCallError::Remote(error)));
                                         }
                                     }
                                     Err(e) => {
@@ -211,6 +217,17 @@ impl PluginProcess {
         params: Value,
         timeout: Duration,
     ) -> Result<Value, String> {
+        self.call_detailed(method, params, timeout)
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    async fn call_detailed(
+        &self,
+        method: &str,
+        params: Value,
+        timeout: Duration,
+    ) -> Result<Value, PluginCallError> {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let req = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
@@ -227,7 +244,7 @@ impl PluginProcess {
 
         match tokio::time::timeout(timeout, rx).await {
             Ok(Ok(result)) => result,
-            Ok(Err(_)) => Err("Plugin process did not respond".to_string()),
+            Ok(Err(_)) => Err("Plugin process did not respond".to_string().into()),
             Err(_) => {
                 // Tell the management task to drop the now-orphaned pending
                 // entry so it does not leak one slot per timeout.
@@ -236,7 +253,8 @@ impl PluginProcess {
                     "Plugin call '{}' timed out after {}s",
                     method,
                     timeout.as_secs()
-                ))
+                )
+                .into())
             }
         }
     }
@@ -246,6 +264,9 @@ pub struct RpcDriver {
     manifest: PluginManifest,
     process: Arc<PluginProcess>,
     data_types: Vec<DataTypeInfo>,
+    connection_metadata: bool,
+    metadata_cache: Arc<ConnectionMetadataCache>,
+    connection_params: Option<ConnectionParams>,
 }
 
 impl RpcDriver {
@@ -272,14 +293,81 @@ impl RpcDriver {
             manifest,
             process,
             data_types,
+            connection_metadata: false,
+            metadata_cache: Arc::new(ConnectionMetadataCache::default()),
+            connection_params: None,
         })
+    }
+
+    /// SQL-building methods historically had no connection parameters. Add
+    /// them only for opted-in snapshots; legacy plugin request shapes stay intact.
+    async fn call_with_connection(
+        &self,
+        method: &str,
+        mut arguments: Value,
+    ) -> Result<Value, String> {
+        if let Some(params) = &self.connection_params {
+            if let Some(object) = arguments.as_object_mut() {
+                object.entry("params").or_insert_with(|| json!(params));
+            }
+        }
+        self.process.call(method, arguments).await
+    }
+
+    pub fn with_connection_metadata(mut self, enabled: bool) -> Self {
+        self.connection_metadata = enabled;
+        self
     }
 }
 
 #[async_trait]
 impl DatabaseDriver for RpcDriver {
+    fn has_connection_metadata(&self) -> bool {
+        self.connection_metadata
+    }
+
     fn manifest(&self) -> &PluginManifest {
         &self.manifest
+    }
+
+    async fn for_connection(
+        &self,
+        params: &ConnectionParams,
+    ) -> Result<Option<Arc<dyn DatabaseDriver>>, String> {
+        if !self.connection_metadata {
+            return Ok(None);
+        }
+        let cell = self.metadata_cache.entry(params).await?;
+        let metadata = cell.get_or_try_init(|| async {
+            let overrides = match self.process.call_detailed(
+                "get_connection_metadata", json!({ "params": params }), PLUGIN_CALL_TIMEOUT,
+            ).await {
+                Ok(value) => serde_json::from_value::<ConnectionMetadataOverrides>(value)
+                    .map_err(|e| format!("Invalid connection metadata: {}", e))?,
+                Err(PluginCallError::Remote(error)) if error.code == -32601 => {
+                    log::warn!("Plugin '{}' declares connection metadata but does not implement the RPC; using its manifest", self.manifest.id);
+                    ConnectionMetadataOverrides::default()
+                }
+                Err(error) => return Err(format!("Connection metadata discovery failed: {}", error)),
+            };
+            overrides.resolve(&self.manifest, &self.data_types)
+        }).await?;
+        let mut manifest = self.manifest.clone();
+        manifest.capabilities = metadata.capabilities.clone();
+        manifest.type_mappings = metadata.type_mappings.clone();
+        Ok(Some(Arc::new(Self {
+            manifest,
+            process: self.process.clone(),
+            data_types: metadata.data_types.clone(),
+            // The returned snapshot is already resolved for this operation.
+            connection_metadata: false,
+            metadata_cache: self.metadata_cache.clone(),
+            connection_params: Some(params.clone()),
+        })))
+    }
+
+    async fn invalidate_connection_metadata(&self, connection_id: Option<&str>) {
+        self.metadata_cache.invalidate(connection_id).await;
     }
 
     async fn shutdown(&self) {
@@ -658,8 +746,7 @@ impl DatabaseDriver for RpcDriver {
         schema: Option<&str>,
     ) -> Result<String, String> {
         let res = self
-            .process
-            .call(
+            .call_with_connection(
                 "routine_create_template",
                 json!({ "routine_type": routine_type, "schema": schema }),
             )
@@ -963,8 +1050,7 @@ impl DatabaseDriver for RpcDriver {
         schema: Option<&str>,
     ) -> Result<Vec<String>, String> {
         let res = self
-            .process
-            .call(
+            .call_with_connection(
                 "get_create_table_sql",
                 json!({ "table_name": table_name, "columns": columns, "schema": schema }),
             )
@@ -979,8 +1065,7 @@ impl DatabaseDriver for RpcDriver {
         schema: Option<&str>,
     ) -> Result<Vec<String>, String> {
         let res = self
-            .process
-            .call(
+            .call_with_connection(
                 "get_add_column_sql",
                 json!({ "table": table, "column": column, "schema": schema }),
             )
@@ -995,7 +1080,7 @@ impl DatabaseDriver for RpcDriver {
         new_column: ColumnDefinition,
         schema: Option<&str>,
     ) -> Result<Vec<String>, String> {
-        let res = self.process.call("get_alter_column_sql", json!({ "table": table, "old_column": old_column, "new_column": new_column, "schema": schema })).await?;
+        let res = self.call_with_connection("get_alter_column_sql", json!({ "table": table, "old_column": old_column, "new_column": new_column, "schema": schema })).await?;
         serde_json::from_value(res).map_err(|e| e.to_string())
     }
 
@@ -1007,7 +1092,7 @@ impl DatabaseDriver for RpcDriver {
         is_unique: bool,
         schema: Option<&str>,
     ) -> Result<Vec<String>, String> {
-        let res = self.process.call("get_create_index_sql", json!({ "table": table, "index_name": index_name, "columns": columns, "is_unique": is_unique, "schema": schema })).await?;
+        let res = self.call_with_connection("get_create_index_sql", json!({ "table": table, "index_name": index_name, "columns": columns, "is_unique": is_unique, "schema": schema })).await?;
         serde_json::from_value(res).map_err(|e| e.to_string())
     }
 
@@ -1023,6 +1108,7 @@ impl DatabaseDriver for RpcDriver {
         on_update: Option<&str>,
         schema: Option<&str>,
     ) -> Result<Vec<String>, String> {
+        let params = self.connection_params.as_ref().unwrap_or(params);
         let res = self.process.call("get_create_foreign_key_sql", json!({ "params": params, "table": table, "fk_name": fk_name, "column": column, "ref_table": ref_table, "ref_column": ref_column, "on_delete": on_delete, "on_update": on_update, "schema": schema })).await?;
         serde_json::from_value(res).map_err(|e| e.to_string())
     }
@@ -1073,8 +1159,7 @@ impl DatabaseDriver for RpcDriver {
 
     async fn get_db_privilege_catalog(&self) -> Result<DbPrivilegeCatalog, String> {
         let res = self
-            .process
-            .call("get_db_privilege_catalog", json!({}))
+            .call_with_connection("get_db_privilege_catalog", json!({}))
             .await?;
         serde_json::from_value(res).map_err(|e| e.to_string())
     }
@@ -1416,7 +1501,7 @@ mod tests {
                     }))
                     .map_err(|_| "request assertion failed".to_string())
                     .and_then(|outcome| outcome);
-                    let _ = response_tx.send(result);
+                    let _ = response_tx.send(result.map_err(PluginCallError::Transport));
                 }
             }
         });
@@ -1431,6 +1516,9 @@ mod tests {
                 pid: None,
             }),
             data_types: Vec::new(),
+            connection_metadata: false,
+            metadata_cache: Arc::new(ConnectionMetadataCache::default()),
+            connection_params: None,
         }
     }
 
@@ -2198,6 +2286,9 @@ mod tests {
                 pid: None,
             }),
             data_types: Vec::new(),
+            connection_metadata: false,
+            metadata_cache: Arc::new(ConnectionMetadataCache::default()),
+            connection_params: None,
         };
 
         // Mapped types
@@ -2224,6 +2315,9 @@ mod tests {
                 pid: None,
             }),
             data_types: Vec::new(),
+            connection_metadata: false,
+            metadata_cache: Arc::new(ConnectionMetadataCache::default()),
+            connection_params: None,
         };
 
         assert_eq!(driver.map_inferred_type("DATETIME"), "DATETIME");

--- a/src-tauri/src/plugins/manager.rs
+++ b/src-tauri/src/plugins/manager.rs
@@ -47,6 +47,9 @@ pub struct ConfigManifest {
     pub capabilities: DriverCapabilities,
     #[serde(default)]
     pub data_types: Vec<DataTypeInfo>,
+    /// Opt in to the get_connection_metadata RPC. Omitted by existing plugins.
+    #[serde(default)]
+    pub connection_metadata: bool,
     /// Absent for UI-only plugins that ship no driver executable.
     #[serde(default)]
     pub executable: Option<String>,
@@ -258,7 +261,8 @@ pub async fn load_plugin_from_dir(
         config.data_types,
         settings,
     )
-    .await?;
+    .await?
+    .with_connection_metadata(config.connection_metadata);
     crate::drivers::registry::register_driver(driver).await;
     Ok(())
 }

--- a/src-tauri/src/plugins/mod.rs
+++ b/src-tauri/src/plugins/mod.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub mod compat; // COMPAT(registry-ga): remove with the BC layer
+pub mod connection_metadata;
 pub mod deep_link;
 pub mod driver;
 pub mod force_install;

--- a/src-tauri/src/plugins/rpc.rs
+++ b/src-tauri/src/plugins/rpc.rs
@@ -15,6 +15,29 @@ pub struct JsonRpcError {
     pub message: String,
 }
 
+/// Preserve remote error codes internally without changing legacy callers'
+/// error strings. Discovery falls back only on the remote -32601 code.
+#[derive(Debug)]
+pub enum PluginCallError {
+    Remote(JsonRpcError),
+    Transport(String),
+}
+
+impl std::fmt::Display for PluginCallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Remote(error) => f.write_str(&error.message),
+            Self::Transport(message) => f.write_str(message),
+        }
+    }
+}
+
+impl From<String> for PluginCallError {
+    fn from(message: String) -> Self {
+        Self::Transport(message)
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
 pub enum JsonRpcResponse {

--- a/src-tauri/src/task_manager.rs
+++ b/src-tauri/src/task_manager.rs
@@ -359,6 +359,8 @@ pub async fn restart_plugin_process(
         .await
         .map_err(|e| format!("Failed to restart plugin '{}': {}", plugin_id, e))?;
 
+    crate::plugins::connection_metadata::notify_plugin_reload(&app, &plugin_id).await;
+
     Ok(())
 }
 

--- a/src-tauri/tests/fixtures/connection_metadata_plugin.py
+++ b/src-tauri/tests/fixtures/connection_metadata_plugin.py
@@ -1,0 +1,53 @@
+"""Deterministic stdio plugin for connection metadata protocol tests."""
+
+import json
+import sys
+
+discoveries = 0
+for line in sys.stdin:
+    request = json.loads(line)
+    method = request["method"]
+    params = request.get("params", {}).get("params", {})
+    response = {"jsonrpc": "2.0", "id": request["id"]}
+    if method == "get_connection_metadata":
+        discoveries += 1
+        case = params.get("extra", {}).get("case")
+        if case == "missing":
+            response["error"] = {"code": -32601, "message": "Unrecognized operation"}
+        elif case == "failure":
+            response["error"] = {
+                "code": -32000,
+                "message": "Authentication failed; method not found -32601 in diagnostic text",
+            }
+        elif case == "malformed":
+            response["result"] = {"capabilities": {"schemas": "yes"}}
+        elif case == "null":
+            response["result"] = None
+        else:
+            postgres = "postgresql" in params.get("connection_uri", "")
+            response["result"] = {
+                "capabilities": {
+                    "schemas": postgres,
+                    "views": True,
+                    "routines": False,
+                    "identifier_quote": '"' if postgres else "`",
+                    "sql_dialect": "postgres" if postgres else "mysql",
+                    "manage_tables": False,
+                },
+                "data_types": [{
+                    "name": "JSONB" if postgres else "JSON",
+                    "category": "json",
+                    "requires_length": False,
+                    "requires_precision": False,
+                }],
+                "type_mappings": {"JSON": "JSONB" if postgres else "JSON"},
+            }
+    elif method == "get_databases":
+        response["result"] = [str(discoveries)]
+    elif method in ("get_create_table_sql", "get_create_foreign_key_sql"):
+        response["result"] = [params.get("connection_uri", "no-connection-params")]
+    elif method == "build_routine_call_sql":
+        response["error"] = {"code": -32601, "message": "Method not found"}
+    else:
+        response["result"] = None
+    print(json.dumps(response), flush=True)

--- a/src/components/modals/ClipboardImportModal.tsx
+++ b/src/components/modals/ClipboardImportModal.tsx
@@ -89,6 +89,7 @@ export function ClipboardImportModal({ isOpen, onClose, onSuccess }: ClipboardIm
       try {
         const mapped = await invoke<string[]>('map_inferred_column_types', {
           driver: activeDriver,
+          connectionId: activeConnectionId,
           kinds: inferred.map((c) => c.sqlType),
         });
         return base.map((c, i) => ({ ...c, sqlType: mapped[i] ?? c.sqlType }));
@@ -96,7 +97,7 @@ export function ClipboardImportModal({ isOpen, onClose, onSuccess }: ClipboardIm
         return base;
       }
     },
-    [activeDriver],
+    [activeDriver, activeConnectionId],
   );
 
   const tableExists = existingTables.some(

--- a/src/components/modals/CreateForeignKeyModal.tsx
+++ b/src/components/modals/CreateForeignKeyModal.tsx
@@ -36,9 +36,9 @@ export const CreateForeignKeyModal = ({
   driver
 }: CreateForeignKeyModalProps) => {
   const { t } = useTranslation();
-  const { activeSchema } = useDatabase();
+  const { activeSchema, connectionDataMap } = useDatabase();
   const { allDrivers } = useDrivers();
-  const canCreateFk = supportsCreateForeignKeys(getCapabilitiesForDriver(driver, allDrivers));
+  const canCreateFk = supportsCreateForeignKeys(connectionDataMap[connectionId]?.capabilities ?? getCapabilitiesForDriver(driver, allDrivers));
   const [fkName, setFkName] = useState('');
   const [localColumn, setLocalColumn] = useState('');
   const [refTable, setRefTable] = useState('');

--- a/src/components/modals/ModifyColumnModal.tsx
+++ b/src/components/modals/ModifyColumnModal.tsx
@@ -41,11 +41,11 @@ export const ModifyColumnModal = ({
   column,
 }: ModifyColumnModalProps) => {
   const { t } = useTranslation();
-  const { activeSchema } = useDatabase();
-  const { dataTypes } = useDataTypes(driver);
+  const { activeSchema, connectionDataMap } = useDatabase();
+  const { dataTypes } = useDataTypes(driver, connectionId);
   const { allDrivers } = useDrivers();
   const driverManifest = allDrivers.find((d) => d.id === driver);
-  const driverCapabilities = driverManifest?.capabilities ?? null;
+  const driverCapabilities = connectionDataMap[connectionId]?.capabilities ?? driverManifest?.capabilities ?? null;
   const canAlterPk = driverCapabilities?.alter_primary_key !== false;
   const canAlterColumn = supportsAlterColumn(driverCapabilities);
   const isEdit = !!column;

--- a/src/contexts/DatabaseContext.ts
+++ b/src/contexts/DatabaseContext.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import type { DriverCapabilities } from '../types/plugins';
+import type { ConnectionMetadata, DriverCapabilities } from '../types/plugins';
 
 export interface TableInfo {
   name: string;
@@ -101,6 +101,8 @@ export interface SchemaData {
 export interface ConnectionData {
   driver: string;
   capabilities: DriverCapabilities | null;
+  metadata?: ConnectionMetadata;
+  usesConnectionMetadata?: boolean;
   connectionName: string;
   databaseName: string;
   tables: TableInfo[];

--- a/src/contexts/DatabaseProvider.tsx
+++ b/src/contexts/DatabaseProvider.tsx
@@ -15,8 +15,9 @@ import {
   type ConnectionsFile,
 } from './DatabaseContext';
 import type { ReactNode } from 'react';
-import type { PluginManifest } from '../types/plugins';
+import type { ConnectionMetadata, PluginManifest } from '../types/plugins';
 import { clearAutocompleteCache } from '../utils/autocomplete';
+import { loadOptionalMetadata } from '../utils/connectionMetadata';
 import { toErrorMessage } from '../utils/errors';
 import { useSettings } from '../hooks/useSettings';
 import { useToast } from '../hooks/useToast';
@@ -98,6 +99,7 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
   openConnectionIdsRef.current = openConnectionIds;
   const connectionDataMapRef = useRef(connectionDataMap);
   connectionDataMapRef.current = connectionDataMap;
+  const connectionAttemptsRef = useRef(new Map<string, symbol>());
   const prevActiveExtRef = useRef<string[] | undefined>(undefined);
 
   const getActiveConnectionData = useCallback((): ConnectionData | undefined => {
@@ -297,7 +299,7 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
     if (!connId) return;
     updateConnectionData(connId, { isLoadingViews: true });
     try {
-      const result = await invoke<ViewInfo[]>('get_views', { connectionId: connId });
+      const result = await loadOptionalMetadata(connectionDataMap[connId]?.metadata?.capabilities.views, () => invoke<ViewInfo[]>('get_views', { connectionId: connId }), []);
       updateConnectionData(connId, { views: result, isLoadingViews: false });
     } catch (e) {
       console.error('Failed to refresh views:', e);
@@ -310,7 +312,7 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
     if (!connId) return;
     updateConnectionData(connId, { isLoadingRoutines: true });
     try {
-      const result = await invoke<RoutineInfo[]>('get_routines', { connectionId: connId });
+      const result = await loadOptionalMetadata(connectionDataMap[connId]?.metadata?.capabilities.routines, () => invoke<RoutineInfo[]>('get_routines', { connectionId: connId }), []);
       updateConnectionData(connId, {
         routines: result,
         isLoadingRoutines: false,
@@ -330,7 +332,7 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
     if (!connId) return;
     updateConnectionData(connId, { isLoadingTriggers: true });
     try {
-      const result = await invoke<TriggerInfo[]>('get_triggers', { connectionId: connId });
+      const result = await loadOptionalMetadata(connectionDataMap[connId]?.metadata?.capabilities.triggers, () => invoke<TriggerInfo[]>('get_triggers', { connectionId: connId }), []);
       updateConnectionData(connId, { triggers: result, isLoadingTriggers: false });
     } catch (e) {
       console.error('Failed to refresh triggers:', e);
@@ -358,12 +360,12 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
     try {
       const [tablesResult, viewsResult, materializedViewsResult, routineMetadata, triggersResult] = await Promise.all([
         invoke<TableInfo[]>('get_tables', { connectionId: connId, schema }),
-        invoke<ViewInfo[]>('get_views', { connectionId: connId, schema }),
+        loadOptionalMetadata(currentData.metadata?.capabilities.views, () => invoke<ViewInfo[]>('get_views', { connectionId: connId, schema }), [] as ViewInfo[]),
         (currentData.capabilities?.materialized_views
           ? invoke<ViewInfo[]>('get_materialized_views', { connectionId: connId, schema }).catch(() => [] as ViewInfo[])
           : Promise.resolve([] as ViewInfo[])),
-        getRoutinesOrEmpty(connId, schema, handleRoutineMetadataError),
-        invoke<TriggerInfo[]>('get_triggers', { connectionId: connId, schema }).catch(() => [] as TriggerInfo[]),
+        loadOptionalMetadata(currentData.metadata?.capabilities.routines, () => getRoutinesOrEmpty(connId, schema, handleRoutineMetadataError), { routines: [] }),
+        loadOptionalMetadata(currentData.metadata?.capabilities.triggers, () => invoke<TriggerInfo[]>('get_triggers', { connectionId: connId, schema }).catch(() => [] as TriggerInfo[]), [] as TriggerInfo[]),
       ]);
 
       const freshData = connectionDataMap[connId];
@@ -418,12 +420,12 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
     try {
       const [tablesResult, viewsResult, materializedViewsResult, routineMetadata, triggersResult] = await Promise.all([
         invoke<TableInfo[]>('get_tables', { connectionId: connId, schema }),
-        invoke<ViewInfo[]>('get_views', { connectionId: connId, schema }),
+        loadOptionalMetadata(currentData.metadata?.capabilities.views, () => invoke<ViewInfo[]>('get_views', { connectionId: connId, schema }), [] as ViewInfo[]),
         (currentData.capabilities?.materialized_views
           ? invoke<ViewInfo[]>('get_materialized_views', { connectionId: connId, schema }).catch(() => [] as ViewInfo[])
           : Promise.resolve([] as ViewInfo[])),
-        getRoutinesOrEmpty(connId, schema, handleRoutineMetadataError),
-        invoke<TriggerInfo[]>('get_triggers', { connectionId: connId, schema }).catch(() => [] as TriggerInfo[]),
+        loadOptionalMetadata(currentData.metadata?.capabilities.routines, () => getRoutinesOrEmpty(connId, schema, handleRoutineMetadataError), { routines: [] }),
+        loadOptionalMetadata(currentData.metadata?.capabilities.triggers, () => invoke<TriggerInfo[]>('get_triggers', { connectionId: connId, schema }).catch(() => [] as TriggerInfo[]), [] as TriggerInfo[]),
       ]);
 
       const freshData = connectionDataMap[connId];
@@ -481,9 +483,9 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
     try {
       const [tablesResult, viewsResult, routineMetadata, triggersResult] = await Promise.all([
         invoke<TableInfo[]>('get_tables', { connectionId: connId, schema: database }),
-        invoke<ViewInfo[]>('get_views', { connectionId: connId, schema: database }),
-        getRoutinesOrEmpty(connId, database, handleRoutineMetadataError),
-        invoke<TriggerInfo[]>('get_triggers', { connectionId: connId, schema: database }).catch(() => [] as TriggerInfo[]),
+        loadOptionalMetadata(currentData.metadata?.capabilities.views, () => invoke<ViewInfo[]>('get_views', { connectionId: connId, schema: database }), [] as ViewInfo[]),
+        loadOptionalMetadata(currentData.metadata?.capabilities.routines, () => getRoutinesOrEmpty(connId, database, handleRoutineMetadataError), { routines: [] }),
+        loadOptionalMetadata(currentData.metadata?.capabilities.triggers, () => invoke<TriggerInfo[]>('get_triggers', { connectionId: connId, schema: database }).catch(() => [] as TriggerInfo[]), [] as TriggerInfo[]),
       ]);
 
       const freshData = connectionDataMap[connId];
@@ -537,9 +539,9 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
     try {
       const [tablesResult, viewsResult, routineMetadata, triggersResult] = await Promise.all([
         invoke<TableInfo[]>('get_tables', { connectionId: connId, schema: database }),
-        invoke<ViewInfo[]>('get_views', { connectionId: connId, schema: database }),
-        getRoutinesOrEmpty(connId, database, handleRoutineMetadataError),
-        invoke<TriggerInfo[]>('get_triggers', { connectionId: connId, schema: database }).catch(() => [] as TriggerInfo[]),
+        loadOptionalMetadata(currentData.metadata?.capabilities.views, () => invoke<ViewInfo[]>('get_views', { connectionId: connId, schema: database }), [] as ViewInfo[]),
+        loadOptionalMetadata(currentData.metadata?.capabilities.routines, () => getRoutinesOrEmpty(connId, database, handleRoutineMetadataError), { routines: [] }),
+        loadOptionalMetadata(currentData.metadata?.capabilities.triggers, () => invoke<TriggerInfo[]>('get_triggers', { connectionId: connId, schema: database }).catch(() => [] as TriggerInfo[]), [] as TriggerInfo[]),
       ]);
 
       const freshData = connectionDataMap[connId];
@@ -648,6 +650,12 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
   }, [activeConnectionId, connectionDataMap, updateConnectionData, loadDatabaseData]);
 
   const connect = async (connectionId: string) => {
+    const attempt = Symbol(connectionId);
+    connectionAttemptsRef.current.set(connectionId, attempt);
+    const isCurrentAttempt = () => connectionAttemptsRef.current.get(connectionId) === attempt;
+    const updateCurrentConnection = (id: string, updates: Partial<ConnectionData>) => {
+      if (isCurrentAttempt()) updateConnectionData(id, updates);
+    };
     // Capture previous state so we can restore it on failure
     const prevActiveConnectionId = activeConnectionId;
 
@@ -688,13 +696,14 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
         // Manifest not found; capabilities will be null and features will degrade gracefully
       }
 
-      const capabilities = driverManifest?.capabilities ?? null;
+      let capabilities = driverManifest?.capabilities ?? null;
       const dbParam = conn.params.database; // string | string[]
       const primaryDb = getEffectiveDatabase(dbParam);
 
-      updateConnectionData(connectionId, {
+      updateCurrentConnection(connectionId, {
         driver,
         capabilities,
+        usesConnectionMetadata: driverManifest?.connection_metadata === true,
         connectionName: conn.name,
         databaseName: primaryDb,
       });
@@ -708,7 +717,7 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
         });
       } catch (testError) {
         const errorMsg = toErrorMessage(testError);
-        updateConnectionData(connectionId, {
+        updateCurrentConnection(connectionId, {
           isConnecting: false,
           isConnected: false,
           isLoadingTables: false,
@@ -718,6 +727,16 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
         });
         setOpenConnectionIds(prev => prev.filter(id => id !== connectionId));
         throw new Error(errorMsg);
+      }
+
+      if (!isCurrentAttempt()) return;
+      const metadata = driverManifest?.connection_metadata
+        ? await invoke<ConnectionMetadata | null>("get_connection_metadata", { connectionId })
+        : null;
+      if (!isCurrentAttempt()) return;
+      if (metadata) {
+        capabilities = metadata.capabilities;
+        updateCurrentConnection(connectionId, { capabilities, metadata });
       }
 
       // Register for health-check pinging.
@@ -745,7 +764,7 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
           // Without a database list the connection is unusable (it has no
           // default schema) — fail the connect with the real error.
           const errorMsg = toErrorMessage(e);
-          updateConnectionData(connectionId, {
+          updateCurrentConnection(connectionId, {
             isConnecting: false,
             isConnected: false,
             isLoadingTables: false,
@@ -801,9 +820,9 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
           try {
             const [tablesResult, viewsResult, routineMetadata, triggersResult] = await Promise.all([
               invoke<TableInfo[]>('get_tables', { connectionId, schema: firstDb }),
-              invoke<ViewInfo[]>('get_views', { connectionId, schema: firstDb }),
-              getRoutinesOrEmpty(connectionId, firstDb, handleRoutineMetadataError),
-              invoke<TriggerInfo[]>('get_triggers', { connectionId, schema: firstDb }).catch(() => [] as TriggerInfo[]),
+              loadOptionalMetadata(metadata?.capabilities.views, () => invoke<ViewInfo[]>('get_views', { connectionId, schema: firstDb }), [] as ViewInfo[]),
+              loadOptionalMetadata(metadata?.capabilities.routines, () => getRoutinesOrEmpty(connectionId, firstDb, handleRoutineMetadataError), { routines: [] }),
+              loadOptionalMetadata(metadata?.capabilities.triggers, () => invoke<TriggerInfo[]>('get_triggers', { connectionId, schema: firstDb }).catch(() => [] as TriggerInfo[]), [] as TriggerInfo[]),
             ]);
             initialDbMap = {
               [firstDb]: {
@@ -821,7 +840,7 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
           }
         }
 
-        updateConnectionData(connectionId, {
+        updateCurrentConnection(connectionId, {
           selectedDatabases: dbList,
           databaseDataMap: initialDbMap,
           allDatabasesMode,
@@ -839,11 +858,11 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
           isConnected: true,
         });
       } else if (capabilities?.schemas === true) {
-        updateConnectionData(connectionId, { isLoadingSchemas: true });
+        updateCurrentConnection(connectionId, { isLoadingSchemas: true });
 
         try {
           const schemasResult = await invoke<string[]>('get_schemas', { connectionId });
-          updateConnectionData(connectionId, { schemas: schemasResult });
+          updateCurrentConnection(connectionId, { schemas: schemasResult });
 
           let savedSelection: string[] = [];
           try {
@@ -867,15 +886,15 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
 
             const [tablesResult, viewsResult, materializedViewsResult, routineMetadata, triggersResult] = await Promise.all([
               invoke<TableInfo[]>('get_tables', { connectionId, schema: preferredSchema }),
-              invoke<ViewInfo[]>('get_views', { connectionId, schema: preferredSchema }),
+              loadOptionalMetadata(metadata?.capabilities.views, () => invoke<ViewInfo[]>('get_views', { connectionId, schema: preferredSchema }), [] as ViewInfo[]),
               (capabilities?.materialized_views
                 ? invoke<ViewInfo[]>('get_materialized_views', { connectionId, schema: preferredSchema }).catch(() => [] as ViewInfo[])
                 : Promise.resolve([] as ViewInfo[])),
-              getRoutinesOrEmpty(connectionId, preferredSchema, handleRoutineMetadataError),
-              invoke<TriggerInfo[]>('get_triggers', { connectionId, schema: preferredSchema }).catch(() => [] as TriggerInfo[]),
+              loadOptionalMetadata(metadata?.capabilities.routines, () => getRoutinesOrEmpty(connectionId, preferredSchema, handleRoutineMetadataError), { routines: [] }),
+              loadOptionalMetadata(metadata?.capabilities.triggers, () => invoke<TriggerInfo[]>('get_triggers', { connectionId, schema: preferredSchema }).catch(() => [] as TriggerInfo[]), [] as TriggerInfo[]),
             ]);
 
-            updateConnectionData(connectionId, {
+            updateCurrentConnection(connectionId, {
               selectedSchemas: validSelection,
               needsSchemaSelection: false,
               activeSchema: preferredSchema,
@@ -900,7 +919,7 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
               isConnected: true,
             });
           } else {
-            updateConnectionData(connectionId, {
+            updateCurrentConnection(connectionId, {
               selectedSchemas: [],
               needsSchemaSelection: true,
               isLoadingSchemas: false,
@@ -914,7 +933,7 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
           }
         } catch (e) {
           console.error('Failed to fetch schemas:', e);
-          updateConnectionData(connectionId, {
+          updateCurrentConnection(connectionId, {
             isLoadingSchemas: false,
             isLoadingTables: false,
             isLoadingViews: false,
@@ -930,12 +949,12 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
       } else {
         const [tablesResult, viewsResult, routineMetadata, triggersResult] = await Promise.all([
           invoke<TableInfo[]>('get_tables', { connectionId }),
-          invoke<ViewInfo[]>('get_views', { connectionId }),
-          getRoutinesOrEmpty(connectionId, undefined, handleRoutineMetadataError),
-          invoke<TriggerInfo[]>('get_triggers', { connectionId }).catch(() => [] as TriggerInfo[]),
+          loadOptionalMetadata(metadata?.capabilities.views, () => invoke<ViewInfo[]>('get_views', { connectionId }), [] as ViewInfo[]),
+          loadOptionalMetadata(metadata?.capabilities.routines, () => getRoutinesOrEmpty(connectionId, undefined, handleRoutineMetadataError), { routines: [] }),
+          loadOptionalMetadata(metadata?.capabilities.triggers, () => invoke<TriggerInfo[]>('get_triggers', { connectionId }).catch(() => [] as TriggerInfo[]), [] as TriggerInfo[]),
         ]);
 
-        updateConnectionData(connectionId, {
+        updateCurrentConnection(connectionId, {
           tables: tablesResult,
           views: viewsResult,
           routines: routineMetadata.routines,
@@ -950,6 +969,7 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
         });
       }
     } catch (error) {
+      if (!isCurrentAttempt()) return;
       console.error('Failed to connect:', error);
       setConnectionDataMap(prev => {
         const newMap = { ...prev };
@@ -966,6 +986,7 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
     const targetId = connectionId || activeConnectionId;
     if (!targetId) return;
 
+    connectionAttemptsRef.current.delete(targetId);
     clearAutocompleteCache(targetId);
 
     try {
@@ -1002,6 +1023,7 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const detachConnection = useCallback((connectionId: string) => {
+    connectionAttemptsRef.current.delete(connectionId);
     clearAutocompleteCache(connectionId);
 
     setOpenConnectionIds(prev => prev.filter(id => id !== connectionId));
@@ -1110,12 +1132,42 @@ export const DatabaseProvider = ({ children }: { children: ReactNode }) => {
     invoke('set_last_open_connections', { connectionIds: openConnectionIds }).catch(() => {});
   }, [openConnectionIds]);
 
+  // Invalidate open dynamic contexts when their saved parameters or plugin change.
+  useEffect(() => {
+    const unlisten = listen<{ connectionId?: string; driverId?: string }>(
+      'connection-metadata-invalidated',
+      ({ payload }) => {
+        const ids = Object.entries(connectionDataMapRef.current)
+          .filter(([id, data]) => data.usesConnectionMetadata &&
+            (id === payload.connectionId || data.driver === payload.driverId))
+          .map(([id]) => id);
+        if (ids.length === 0) return;
+        for (const id of ids) {
+          connectionAttemptsRef.current.delete(id);
+          clearAutocompleteCache(id);
+          void invoke('disconnect_connection', { connectionId: id }).catch(error => {
+            console.error('Failed to release invalidated connection:', error);
+          });
+        }
+        setOpenConnectionIds(previous => previous.filter(id => !ids.includes(id)));
+        setConnectionDataMap(previous => Object.fromEntries(
+          Object.entries(previous).filter(([id]) => !ids.includes(id)),
+        ));
+        setActiveConnectionId(previous => previous && ids.includes(previous)
+          ? openConnectionIdsRef.current.find(id => !ids.includes(id)) ?? null
+          : previous);
+      },
+    );
+    return () => { unlisten.then(fn => fn()); };
+  }, []);
+
   // Listen for backend health-check failures and clean up dead connections.
   useEffect(() => {
     const unlisten = listen<{ connectionId: string; error: string }>(
       'connection-health-failed',
       (event) => {
         const { connectionId } = event.payload;
+        connectionAttemptsRef.current.delete(connectionId);
         console.warn(`[DatabaseProvider] Connection health check failed for ${connectionId}: ${event.payload.error}`);
 
         clearAutocompleteCache(connectionId);

--- a/src/hooks/useDataTypes.ts
+++ b/src/hooks/useDataTypes.ts
@@ -1,48 +1,50 @@
-import { useState, useEffect } from "react";
+import { useContext, useState, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { DatabaseContext } from "../contexts/DatabaseContext";
 import type { DataTypeRegistry } from "../types/dataTypes";
 
 const dataTypesCache = new Map<string, DataTypeRegistry>();
 
-export function useDataTypes(driver: string | undefined) {
-  const [dataTypes, setDataTypes] = useState<DataTypeRegistry | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+export function useDataTypes(driver: string | undefined, connectionId?: string | null) {
+  const context = useContext(DatabaseContext);
+  const targetId = connectionId === undefined ? context?.activeConnectionId : connectionId;
+  const connection = targetId ? context?.connectionDataMap[targetId] : undefined;
+  const metadata = connection?.driver === driver ? connection?.metadata : undefined;
+  const cached = driver ? dataTypesCache.get(driver) : undefined;
+  const [result, setResult] = useState<{
+    driver: string;
+    dataTypes: DataTypeRegistry | null;
+    error: string | null;
+  } | null>(null);
 
   useEffect(() => {
-    if (!driver) {
-      setDataTypes(null);
-      setLoading(false);
-      return;
-    }
-
+    if (!driver || metadata || cached) return;
+    let cancelled = false;
     const fetchDataTypes = async () => {
       try {
-        setLoading(true);
-        setError(null);
-
-        if (dataTypesCache.has(driver)) {
-          setDataTypes(dataTypesCache.get(driver)!);
-          setLoading(false);
-          return;
-        }
-
-        const registry = await invoke<DataTypeRegistry>("get_data_types", {
-          driver,
-        });
-
+        const registry = await invoke<DataTypeRegistry>("get_data_types", { driver });
         dataTypesCache.set(driver, registry);
-        setDataTypes(registry);
+        if (!cancelled) setResult({ driver, dataTypes: registry, error: null });
       } catch (err) {
-        console.error("Failed to fetch data types:", err);
-        setError(String(err));
-      } finally {
-        setLoading(false);
+        if (!cancelled) setResult({ driver, dataTypes: null, error: String(err) });
       }
     };
 
-    fetchDataTypes();
-  }, [driver]);
+    void fetchDataTypes();
+    return () => { cancelled = true; };
+  }, [driver, metadata, cached]);
 
-  return { dataTypes, loading, error };
+  if (driver && metadata) {
+    return {
+      dataTypes: { driver, types: metadata.data_types },
+      loading: false,
+      error: null,
+    };
+  }
+  const current = result?.driver === driver ? result : null;
+  return {
+    dataTypes: current?.dataTypes ?? cached ?? null,
+    loading: Boolean(driver && !current && !cached),
+    error: current?.error ?? null,
+  };
 }

--- a/src/types/plugins.ts
+++ b/src/types/plugins.ts
@@ -65,6 +65,13 @@ export interface DriverCapabilities {
   sql_dialect?: Dialect;
 }
 
+/** Effective metadata for one connection. The registered manifest stays static. */
+export interface ConnectionMetadata {
+  capabilities: DriverCapabilities;
+  data_types: import("./dataTypes").DataTypeInfo[];
+  type_mappings: Record<string, string>;
+}
+
 export type PluginSettingType = "string" | "boolean" | "number" | "select";
 
 export interface PluginSettingDefinition {
@@ -96,6 +103,8 @@ export interface PluginManifest {
   description: string;
   default_port: number | null;
   capabilities: DriverCapabilities;
+  /** Present on get_driver_manifest when the plugin opts in to discovery. */
+  connection_metadata?: boolean;
   /** true for built-in drivers (postgres, mysql, sqlite); false/absent for external plugins */
   is_builtin?: boolean;
   /** Concrete database engine (registry manifest `engine`). Lets the connection

--- a/src/utils/connectionMetadata.ts
+++ b/src/utils/connectionMetadata.ts
@@ -1,0 +1,8 @@
+/** Undefined preserves legacy loading; only an explicit false skips the RPC. */
+export function loadOptionalMetadata<T>(
+  supported: boolean | undefined,
+  load: () => Promise<T>,
+  empty: T,
+): Promise<T> {
+  return supported === false ? Promise.resolve(empty) : load();
+}

--- a/tests/contexts/connectionMetadata.test.tsx
+++ b/tests/contexts/connectionMetadata.test.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { DatabaseProvider } from "../../src/contexts/DatabaseProvider";
+import { useDatabase } from "../../src/hooks/useDatabase";
+import type { ConnectionMetadata, DriverCapabilities } from "../../src/types/plugins";
+
+const { events } = vi.hoisted(() => ({ events: new Map<string, (event: { payload: unknown }) => void>() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn((name: string, callback: (event: { payload: unknown }) => void) => {
+    events.set(name, callback);
+    return Promise.resolve(() => events.delete(name));
+  }),
+}));
+vi.mock("../../src/utils/autocomplete", () => ({ clearAutocompleteCache: vi.fn() }));
+vi.mock("../../src/hooks/useSettings", () => ({
+  useSettings: () => ({ settings: { activeExternalDrivers: ["jdbc"] }, isLoading: false }),
+}));
+
+const capabilities: DriverCapabilities = {
+  schemas: false, views: true, routines: false, file_based: false,
+  folder_based: false, single_database: true, identifier_quote: '"',
+  alter_primary_key: false, manage_tables: false, sql_dialect: "generic",
+};
+const metadata = (pg: boolean): ConnectionMetadata => ({
+  capabilities: { ...capabilities, schemas: pg, views: false, sql_dialect: pg ? "postgres" : "mysql" },
+  data_types: [{ name: pg ? "JSONB" : "JSON", category: "json", requires_length: false,
+    requires_precision: false, supports_auto_increment: false }],
+  type_mappings: { JSON: pg ? "JSONB" : "JSON" },
+});
+const connections = ["pg", "mysql"].map(id => ({
+  id, name: id, params: { driver: "jdbc", database: "example" },
+}));
+
+function defaultInvoke(command: string, args?: Record<string, unknown>): Promise<unknown> {
+  switch (command) {
+    case "get_connections": return Promise.resolve(connections);
+    case "get_connections_with_groups": return Promise.resolve({ connections, groups: [] });
+    case "get_driver_manifest": return Promise.resolve({ id: "jdbc", capabilities, connection_metadata: true });
+    case "get_connection_metadata": return Promise.resolve(metadata(args?.connectionId === "pg"));
+    case "get_schemas": return Promise.resolve(["public"]);
+    case "get_selected_schemas": return Promise.resolve([]);
+    case "get_tables": return Promise.resolve([{ name: "example" }]);
+    case "get_active_connections": return Promise.resolve([]);
+    default: return Promise.resolve(undefined);
+  }
+}
+
+const wrapper = ({ children }: { children: React.ReactNode }) => <DatabaseProvider>{children}</DatabaseProvider>;
+
+describe("connection metadata discovery", () => {
+  beforeEach(() => {
+    events.clear();
+    vi.mocked(invoke).mockReset();
+    vi.mocked(invoke).mockImplementation((command, args) => defaultInvoke(command, args as Record<string, unknown>));
+  });
+
+  it("keeps metadata separate for two connections using one driver", async () => {
+    const { result } = renderHook(() => useDatabase(), { wrapper });
+    await act(async () => result.current.connect("pg"));
+    await act(async () => result.current.connect("mysql"));
+    expect(result.current.connectionDataMap.pg.capabilities?.schemas).toBe(true);
+    expect(result.current.connectionDataMap.mysql.capabilities?.schemas).toBe(false);
+    expect(result.current.connectionDataMap.pg.metadata?.data_types[0].name).toBe("JSONB");
+    expect(result.current.activeCapabilities?.sql_dialect).toBe("mysql");
+    expect(result.current.connectionDataMap.pg.needsSchemaSelection).toBe(true);
+    expect(result.current.connectionDataMap.mysql.tables).toEqual([{ name: "example" }]);
+    expect(invoke).not.toHaveBeenCalledWith("get_views", expect.anything());
+    expect(invoke).not.toHaveBeenCalledWith("get_routines", expect.anything());
+  });
+
+  it("does not request discovery for a static manifest", async () => {
+    vi.mocked(invoke).mockImplementation((command, args) => command === "get_driver_manifest"
+      ? Promise.resolve({ id: "jdbc", capabilities: { ...capabilities, schemas: true } })
+      : defaultInvoke(command, args as Record<string, unknown>));
+    const { result } = renderHook(() => useDatabase(), { wrapper });
+    await act(async () => result.current.connect("pg"));
+    expect(invoke).not.toHaveBeenCalledWith("get_connection_metadata", expect.anything());
+    expect(result.current.connectionDataMap.pg.metadata).toBeUndefined();
+    await act(async () => events.get("connection-metadata-invalidated")?.({ payload: { driverId: "jdbc" } }));
+    expect(result.current.openConnectionIds).toEqual(["pg"]);
+  });
+
+  it("surfaces discovery errors before loading database objects", async () => {
+    vi.mocked(invoke).mockImplementation((command, args) => command === "get_connection_metadata"
+      ? Promise.reject(new Error("Discovery permission denied"))
+      : defaultInvoke(command, args as Record<string, unknown>));
+    const { result } = renderHook(() => useDatabase(), { wrapper });
+    await act(async () => {
+      await expect(result.current.connect("pg")).rejects.toThrow("Discovery permission denied");
+    });
+    expect(result.current.openConnectionIds).toEqual([]);
+    expect(invoke).not.toHaveBeenCalledWith("get_schemas", expect.anything());
+  });
+
+  it("discards discovery that completes after disconnect", async () => {
+    let finish: (value: ConnectionMetadata) => void = () => {};
+    let started: () => void = () => {};
+    const discoveryStarted = new Promise<void>(resolve => { started = resolve; });
+    vi.mocked(invoke).mockImplementation((command, args) => command === "get_connection_metadata"
+      ? new Promise(resolve => { finish = resolve as (value: ConnectionMetadata) => void; started(); })
+      : defaultInvoke(command, args as Record<string, unknown>));
+    const { result } = renderHook(() => useDatabase(), { wrapper });
+    let connecting: Promise<void> = Promise.resolve();
+    await act(async () => { connecting = result.current.connect("pg"); await discoveryStarted; });
+    await act(async () => result.current.disconnect("pg"));
+    await act(async () => { finish(metadata(true)); await connecting; });
+    expect(result.current.connectionDataMap.pg).toBeUndefined();
+    expect(result.current.openConnectionIds).toEqual([]);
+  });
+
+  it("invalidates only the edited connection and clears both on plugin reload", async () => {
+    const { result } = renderHook(() => useDatabase(), { wrapper });
+    await act(async () => result.current.connect("pg"));
+    await act(async () => result.current.connect("mysql"));
+    await act(async () => events.get("connection-metadata-invalidated")?.({ payload: { connectionId: "pg" } }));
+    expect(result.current.connectionDataMap.pg).toBeUndefined();
+    expect(result.current.connectionDataMap.mysql.metadata).toBeDefined();
+    await act(async () => events.get("connection-metadata-invalidated")?.({ payload: { driverId: "jdbc" } }));
+    expect(result.current.openConnectionIds).toEqual([]);
+    expect(result.current.activeCapabilities).toBeNull();
+  });
+});

--- a/tests/hooks/useDataTypes.test.tsx
+++ b/tests/hooks/useDataTypes.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { DatabaseContext, type DatabaseContextType } from "../../src/contexts/DatabaseContext";
+import { useDataTypes } from "../../src/hooks/useDataTypes";
+import type { DataTypeInfo, DataTypeRegistry } from "../../src/types/dataTypes";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+const type = (name: string): DataTypeInfo => ({
+  name, category: "json", requires_length: false,
+  requires_precision: false, supports_auto_increment: false,
+});
+
+const context = (activeConnectionId: string, pgTypes: DataTypeInfo[] = [type("JSONB")]) => ({
+  activeConnectionId,
+  connectionDataMap: {
+    pg: { driver: "jdbc", metadata: { data_types: pgTypes } },
+    mysql: { driver: "jdbc", metadata: { data_types: [type("JSON")] } },
+  },
+} as unknown as DatabaseContextType);
+
+describe("useDataTypes", () => {
+  beforeEach(() => vi.mocked(invoke).mockReset());
+
+  it("switches types immediately between connections sharing a driver", () => {
+    let value = context("pg");
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <DatabaseContext.Provider value={value}>{children}</DatabaseContext.Provider>
+    );
+    const { result, rerender } = renderHook(() => useDataTypes("jdbc"), { wrapper });
+    expect(result.current.dataTypes?.types[0].name).toBe("JSONB");
+    value = context("mysql");
+    rerender();
+    expect(result.current.dataTypes?.types[0].name).toBe("JSON");
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("uses an explicit connection instead of the active one", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <DatabaseContext.Provider value={context("mysql")}>{children}</DatabaseContext.Provider>
+    );
+    const { result } = renderHook(() => useDataTypes("jdbc", "pg"), { wrapper });
+    expect(result.current.dataTypes?.types[0].name).toBe("JSONB");
+  });
+
+  it("preserves an explicitly empty dynamic type list", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <DatabaseContext.Provider value={context("pg", [])}>{children}</DatabaseContext.Provider>
+    );
+    const { result } = renderHook(() => useDataTypes("jdbc"), { wrapper });
+    expect(result.current.dataTypes?.types).toEqual([]);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("keeps the static get_data_types request shape", async () => {
+    vi.mocked(invoke).mockResolvedValue({ driver: "static-test", types: [type("TEXT")] });
+    const { result } = renderHook(() => useDataTypes("static-test"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(invoke).toHaveBeenCalledExactlyOnceWith("get_data_types", { driver: "static-test" });
+    expect(result.current.dataTypes?.types[0].name).toBe("TEXT");
+  });
+
+  it("discards a late response for a previous driver", async () => {
+    let finish: (value: DataTypeRegistry) => void = () => {};
+    vi.mocked(invoke).mockImplementation((_command, args) => args?.driver === "slow-test"
+      ? new Promise(resolve => { finish = resolve as (value: DataTypeRegistry) => void; })
+      : Promise.resolve({ driver: "fast-test", types: [type("JSON")] }));
+    const { result, rerender } = renderHook(({ driver }) => useDataTypes(driver), {
+      initialProps: { driver: "slow-test" },
+    });
+    rerender({ driver: "fast-test" });
+    await waitFor(() => expect(result.current.dataTypes?.driver).toBe("fast-test"));
+    await act(async () => finish({ driver: "slow-test", types: [type("STALE")] }));
+    expect(result.current.dataTypes?.driver).toBe("fast-test");
+  });
+
+  it("reuses static types when a second consumer mounts", async () => {
+    vi.mocked(invoke).mockResolvedValue({ driver: "cached-static", types: [type("TEXT")] });
+    const first = renderHook(() => useDataTypes("cached-static"));
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    first.unmount();
+    const second = renderHook(() => useDataTypes("cached-static"));
+    expect(second.result.current.loading).toBe(false);
+    expect(second.result.current.dataTypes?.types[0].name).toBe("TEXT");
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/utils/connectionMetadata.test.ts
+++ b/tests/utils/connectionMetadata.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadOptionalMetadata } from "../../src/utils/connectionMetadata";
+
+describe("loadOptionalMetadata", () => {
+  it("skips disabled metadata without calling the plugin", async () => {
+    const load = vi.fn().mockRejectedValue(new Error("unsupported"));
+    expect(await loadOptionalMetadata(false, load, [])).toEqual([]);
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it.each([true, undefined])("preserves loading when support is %s", async supported => {
+    const load = vi.fn().mockResolvedValue(["public"]);
+    expect(await loadOptionalMetadata(supported, load, [])).toEqual(["public"]);
+    expect(load).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces errors for enabled capabilities", async () => {
+    await expect(loadOptionalMetadata(true, () => Promise.reject(new Error("permission denied")), []))
+      .rejects.toThrow("permission denied");
+  });
+});


### PR DESCRIPTION
This addresses point (a) in [discussion #728](https://github.com/orgs/TabularisDB/discussions/728#discussioncomment-18366742): a generic driver should be able to report capabilities and data types after it knows which database it is connecting to.

Today those values belong to the registered plugin manifest. That works for a plugin targeting one engine, but it gives a JDBC bridge one shared description for every connection. `initialize` cannot solve this because it runs before connection parameters are available.

## The JDBC example

With [tabularis-jdbc](https://github.com/tabularis-jdbc/tabularis-jdbc), two saved connections could use the same plugin:

```text
jdbc:postgresql://localhost:5432/example
jdbc:mysql://localhost:3306/example
```

They should not share a type list or SQL dialect just because both have `driver: "jdbc"`. The PostgreSQL connection can report `JSONB`, PostgreSQL formatting and double-quoted identifiers. The MySQL connection can report its own types, MySQL formatting and backticks. Schema navigation and available actions should follow the connection as well.

The bridge can obtain much of this information from JDBC's `DatabaseMetaData`. The new host contract gives it somewhere to return that information without changing the global manifest.

## What changes

A plugin opts in by adding `"connection_metadata": true` to its manifest. After a successful connection test, Tabularis calls `get_connection_metadata` with the resolved connection parameters, before loading database objects. The response can contain `capabilities`, `data_types` and `type_mappings`.

For example, an abbreviated response from the PostgreSQL connection could be:

```json
{
  "capabilities": {
    "schemas": true,
    "identifier_quote": "\"",
    "sql_dialect": "postgres",
    "routines": false,
    "manage_tables": false
  },
  "type_mappings": { "JSON": "jsonb" }
}
```

The last two flags matter: database support alone does not make an operation available. A bridge should only enable routines or DDL when it implements the corresponding handlers.

The backend creates a driver snapshot for the connection. The registered manifest remains unchanged. Query and metadata commands, SQL builders, export, clipboard import and MCP resolve through that snapshot, so host-generated SQL and type mappings use the same metadata as the UI. SQL builders that previously had no connection parameters receive them only for opted-in plugins.

Discovery results are cached per plugin process, keyed by connection ID and a hash of the resolved parameters. Concurrent requests share the same discovery call. The cache is bounded to 128 entries and retains no raw credentials or connection URLs in its keys. Testing or disconnecting a connection invalidates its entries; changed parameters get a new key, and a new plugin process gets a new cache.

The UI stores the result with each connection. Type selectors and capability checks follow that connection, and metadata loaders skip operations explicitly reported as unsupported. Editing a dynamic connection or reloading its plugin closes the affected contexts so reconnecting obtains fresh metadata. Late discovery responses cannot reopen a context that has been closed.

## Compatibility

- Discovery is off by default. Existing plugins receive no new RPC and keep their existing request shapes, manifest responses and static metadata.
- The Rust driver trait gains default methods. Existing driver implementations do not need to implement discovery, and `RpcDriver::new` keeps its signature.
- Omitted overrides retain the static value. Explicit `false`, an empty type list or an empty mapping replace it. Discovery cannot change connection-form fields or remove a manifest-level read-only restriction.
- Only a remote JSON-RPC error with code `-32601` falls back to the manifest. Authentication errors, transport failures and malformed metadata remain errors and can be retried. Error message text is not used to decide this fallback.
- Older hosts ignore the opt-in. A plugin that needs discovery must declare an appropriate minimum runtime version when this feature is released.

## Validation

- `cargo test --lib --no-fail-fast`: 1,239 passed, 4 ignored.
- `pnpm exec vitest run`: 4,077 passed across 254 files.
- `pnpm build`: passed.
- ESLint on the changed frontend source files: passed.
- The documented JDBC manifest validates against `plugins/manifest.schema.json`.
- GitNexus impact analysis and staged change detection completed. The shared driver dispatch makes this a broad change; the regression tests explicitly check the static-plugin path.

The Rust tests use a real stdio plugin fixture to exercise isolated PostgreSQL/MySQL responses, SQL parameter forwarding, concurrent discovery, cache invalidation and error-code handling. Frontend tests cover connection switching, empty type lists, static caching, failed discovery, invalidation and late responses.

This has not been tested against an adapted Java bridge and live databases. The JDBC repository still needs to implement the new method and route requests to the correct worker; its current first-worker dependency selection is a separate issue. Tabularium's driver-kind schema also needs to accept the opt-in before such a plugin can pass registry validation.

[`plugins/CONNECTION_METADATA.md`](https://github.com/TabularisDB/tabularis/blob/feat/connection-metadata-discovery/plugins/CONNECTION_METADATA.md) documents the full protocol, JDBC mapping considerations and the manual integration checks for that follow-up.
