### PR TITLE
feat: Add missing SQL Server domain and instance_name connection fields

### DIFF
--- a/src-tauri/src/drivers/sqlserver/pool.rs
+++ b/src-tauri/src/drivers/sqlserver/pool.rs
@@ -52,14 +52,17 @@ impl Manager for BridgeManager {
 
 /// Build a `mssql_tiberius_bridge::Config` from Tabularis `ConnectionParams`.
 ///
-/// Consumes: host, port, username, password, database, encrypt,
-/// trust_server_certificate.
-/// `auth_mode` is parsed but actual Windows/Azure AD
+/// Consumes: host, port, username, password, database, instance_name,
+/// encrypt, trust_server_certificate.
+/// `domain` and `auth_mode` are parsed but actual Windows/Azure AD
 /// authentication wiring is deferred to Phase 3.
 pub fn build_config(params: &ConnectionParams) -> Result<Config, String> {
     let mut cfg = Config::new();
     cfg.host(params.host.as_deref().unwrap_or("localhost"));
     cfg.port(params.port.unwrap_or(1433));
+    if let Some(instance_name) = params.instance_name.as_deref() {
+        cfg.instance_name(instance_name);
+    }
     cfg.database(params.database.primary());
     cfg.authentication(AuthMethod::sql_server(
         params.username.as_deref().unwrap_or(""),
@@ -213,8 +216,25 @@ mod tests {
     }
 
     #[test]
+    fn build_config_domain_parse_only() {
+        let mut params = base_params(Some("localhost"), Some(1433), "master");
+        params.domain = Some("CORP".into());
+        assert!(build_config(&params).is_ok());
+    }
+
+    #[test]
+    fn build_config_instance_name() {
+        let mut params = base_params(Some("db.internal"), None, "master");
+        params.instance_name = Some("SQLEXPRESS".into());
+        let cfg = build_config(&params).expect("config builds");
+        assert_eq!(cfg.datasource_string(), r"tcp:db.internal\SQLEXPRESS");
+    }
+
+    #[test]
     fn build_config_all_new_fields_together() {
         let mut params = base_params(Some("prod-sql"), Some(1444), "appdb");
+        params.domain = Some("CORP".into());
+        params.instance_name = Some("REPORTING".into());
         params.encrypt = Some("strict".into());
         params.trust_server_certificate = Some(false);
         params.auth_mode = Some("azure-ad".into());

--- a/src-tauri/src/export_import_tests.rs
+++ b/src-tauri/src/export_import_tests.rs
@@ -36,6 +36,7 @@ mod tests {
                     ssh_key_passphrase: None,
                     save_in_keychain: Some(true),
                     connection_id: None,
+                    ..Default::default()
                 },
                 group_id: Some("group1".to_string()),
                 sort_order: Some(0),

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -149,6 +149,10 @@ pub struct ConnectionParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trust_server_certificate: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instance_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub encrypt: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_mode: Option<String>,

--- a/src-tauri/src/pool_manager_tests.rs
+++ b/src-tauri/src/pool_manager_tests.rs
@@ -64,6 +64,7 @@ mod postgres_ssl_config_tests {
             ssh_key_passphrase: None,
             save_in_keychain: None,
             connection_id: None,
+            ..Default::default()
         }
     }
 
@@ -89,6 +90,7 @@ mod postgres_ssl_config_tests {
             ssh_key_passphrase: None,
             save_in_keychain: None,
             connection_id: None,
+            ..Default::default()
         }
     }
 
@@ -192,6 +194,7 @@ mod postgres_tls_connector_tests {
             ssh_key_passphrase: None,
             save_in_keychain: None,
             connection_id: None,
+            ..Default::default()
         }
     }
 
@@ -273,6 +276,7 @@ mod postgres_tls_connector_tests {
             ssh_key_passphrase: None,
             save_in_keychain: None,
             connection_id: None,
+            ..Default::default()
         };
         let result = build_postgres_tls_connector(&params);
         assert!(result.is_ok());


### PR DESCRIPTION
Adds the remaining SQL Server Phase 2 connection fields from #144:

- `domain` as a parsed/stored field for future Windows/Azure auth support
- `instance_name` wired into `mssql_tiberius_bridge::Config`
- tests for domain parse-only behavior and named instance config

Validation:
- cargo test --lib: 726 passed